### PR TITLE
Add build cache in ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, build, test]
+    needs: [fmt, build-and-test]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure')
@@ -25,30 +25,33 @@ jobs:
     - run: rustup update
     - run: find . -type f -name '*.rs' -print0 | xargs -I {} -0 rustfmt --check "{}"
 
-  build:
+  build-and-test:
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            profile: dev
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
     - run: rustup target add ${{ matrix.target }}
-    - run: cargo clippy --all-targets --profile ${{ matrix.profile }} --target ${{ matrix.target }}
-
-  test:
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            profile: test
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v3
-    - run: rustup update
-    - run: rustup target add ${{ matrix.target }}
-    - run: cargo test --profile ${{ matrix.profile }} --target ${{ matrix.target }}
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: cargo-
+    - uses: actions/cache@v3
+      with:
+        path: target/
+        key: ${{ github.job }}-target-${{ strategy.job-index }}-${{ github.sha }}
+        restore-keys: |
+          ${{ github.job }}-target-${{ strategy.job-index }}
+          ${{ github.job }}-target-
+    - if: github.ref_protected
+      run: rm -fr target
+    - run: cargo clippy --all-targets --target ${{ matrix.target }}
+    - run: cargo test --target ${{ matrix.target }}


### PR DESCRIPTION
### What
Add build and test artifact cache in ci.

### Why
Speed up builds. Uses same pattern as rs-soroban-sdk.