### PR TITLE
Put ledger.json -> .soroban/ledger.json to keep all cli local files contained

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 target/
-.soroban/ledger.json
+.soroban/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.soroban/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 target/
-.soroban/
+.soroban/ledger.json

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -17,7 +17,7 @@ pub struct Cmd {
     #[clap(long, parse(from_os_str))]
     wasm: std::path::PathBuf,
     /// File to persist ledger state
-    #[clap(long, parse(from_os_str), default_value("ledger.json"))]
+    #[clap(long, parse(from_os_str), default_value(".soroban/ledger.json"))]
     ledger_file: std::path::PathBuf,
 }
 

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -43,7 +43,7 @@ pub struct Cmd {
     #[clap(long = "cost")]
     cost: bool,
     /// File to persist ledger state
-    #[clap(long, parse(from_os_str), default_value("ledger.json"))]
+    #[clap(long, parse(from_os_str), default_value(".soroban/ledger.json"))]
     ledger_file: std::path::PathBuf,
 }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, fs::create_dir_all, io};
+use std::{fs::create_dir_all, fs::File, io};
 
 use soroban_env_host::{
     im_rc::OrdMap,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io};
+use std::{fs::File, fs::create_dir_all, io};
 
 use soroban_env_host::{
     im_rc::OrdMap,
@@ -62,6 +62,12 @@ pub fn commit(
     output_file: &std::path::PathBuf,
 ) -> Result<(), Error> {
     //Need to start off with the existing snapshot (new_state) since it's possible the storage_map did not touch every existing entry
+    if let Some(dir) = output_file.parent() {
+        if !dir.exists() {
+            create_dir_all(dir)?;
+        }
+    }
+
     let file = File::create(output_file)?;
     if let Some(s) = storage_map {
         for (lk, ole) in s {


### PR DESCRIPTION
### What

Auto-create `.soroban` dir when needed, and put `ledger.json` in there.

### Why

So it is easy to `.gitignore` all the soroban cli files. (If we add more)

### Known limitations

Default path may not work on windows?