### PR TITLE
cli serve, first pass at sandbox preflights

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - run: find . -type f -name '*.rs' -print0 | xargs -I {} -0 rustfmt --check "{}"
+    - run: find . -type f -name '*.rs' -print0 | xargs -I {} -0 rustfmt --edition 2021 --check "{}"
 
   build-and-test:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - run: find . -type f -name '*.rs' -print0 | xargs -I {} -0 rustfmt --edition 2021 --check "{}"
+    - run: cargo fmt --all --check
 
   build-and-test:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,10 +89,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
+dependencies = [
+ "memchr",
+ "safemem",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cc"
@@ -225,10 +241,77 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand",
+ "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
  "zeroize",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+
+[[package]]
+name = "futures-task"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-util"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -249,7 +332,18 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -259,10 +353,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
+name = "h2"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.3",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
+
+[[package]]
+name = "headers"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha-1 0.10.0",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heck"
@@ -284,6 +422,75 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "im-rc"
@@ -310,6 +517,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +544,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
+name = "lock_api"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +561,12 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -349,12 +581,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
+]
+
+[[package]]
+name = "multipart"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
+dependencies = [
+ "buf_redux",
+ "httparse",
+ "log",
+ "mime",
+ "mime_guess",
+ "quick-error",
+ "rand 0.8.5",
+ "safemem",
+ "tempfile",
+ "twoway",
 ]
 
 [[package]]
@@ -400,6 +678,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +719,67 @@ name = "parity-wasm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pin-project"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -472,6 +821,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,11 +841,22 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -504,12 +870,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -517,6 +893,9 @@ name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.7",
+]
 
 [[package]]
 name = "rand_hc"
@@ -537,6 +916,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +944,24 @@ name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -580,6 +995,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +1055,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +1080,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+
+[[package]]
+name = "socket2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "soroban-cli"
 version = "0.0.2"
 dependencies = [
@@ -627,9 +1112,13 @@ dependencies = [
  "clap",
  "hex",
  "num-bigint",
+ "serde",
+ "serde_derive",
  "serde_json",
  "soroban-env-host",
  "thiserror",
+ "tokio",
+ "warp",
 ]
 
 [[package]]
@@ -764,6 +1253,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,10 +1317,170 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tokio"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
+dependencies = [
+ "futures-util",
+ "log",
+ "pin-project",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+dependencies = [
+ "cfg-if",
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "tungstenite"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha-1 0.9.8",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "twoway"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
@@ -826,10 +1489,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "version_check"
@@ -838,10 +1528,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cef4e1e9114a4b7f1ac799f16ce71c14de5778500c5450ec6b7b920c55b587e"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
+ "multipart",
+ "percent-encoding",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util 0.6.10",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"
@@ -873,6 +1609,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ soroban-env-host = { version = "0.0.3", git = "https://github.com/stellar/rs-sor
 clap = { version = "3.1.18", features = ["derive", "env"] }
 base64 = "0.13.0"
 thiserror = "1.0.31"
+serde = "1.0.82"
+serde_derive = "1.0.82"
 serde_json = "1.0.82"
 hex = "0.4.3"
 num-bigint = "0.4"
+tokio = { version = "1", features = ["full"] }
+warp = "0.3"

--- a/src/contractspec.rs
+++ b/src/contractspec.rs
@@ -1,0 +1,21 @@
+use std::{io::Cursor, rc::Rc};
+
+use soroban_env_host::{
+    xdr::{ReadXdr, ScSpecEntry, ScSpecFunctionV0},
+    Vm,
+};
+
+pub fn function_spec(vm: &Rc<Vm>, name: &str) -> Option<ScSpecFunctionV0> {
+    let spec = vm.custom_section("contractspecv0")?;
+    let mut cursor = Cursor::new(spec);
+    for spec_entry in ScSpecEntry::read_xdr_iter(&mut cursor).flatten() {
+        if let ScSpecEntry::FunctionV0(f) = spec_entry {
+            if let Ok(n) = f.name.to_string() {
+                if n == name {
+                    return Some(f);
+                }
+            }
+        }
+    }
+    None
+}

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -142,7 +142,7 @@ impl Cmd {
         Ok(())
     }
 
-    fn function_spec(vm: &Rc<Vm>, name: &str) -> Option<ScSpecFunctionV0> {
+    pub fn function_spec(vm: &Rc<Vm>, name: &str) -> Option<ScSpecFunctionV0> {
         let spec = vm.custom_section("contractspecv0")?;
         let mut cursor = Cursor::new(spec);
         for spec_entry in ScSpecEntry::read_xdr_iter(&mut cursor).flatten() {

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -1,0 +1,63 @@
+use std::fmt::Debug;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Clone, Hash, Eq, Deserialize, Serialize, PartialOrd, Ord)]
+#[serde(deny_unknown_fields)]
+#[serde(untagged)]
+pub enum Id {
+	/// Null
+	Null,
+	/// Numeric id
+	Number(u64),
+	/// String id
+	Str(String),
+}
+
+/// JSON-RPC request object as defined in the [spec](https://www.jsonrpc.org/specification#request-object).
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct Request<T> {
+	/// JSON-RPC version.
+	pub jsonrpc: String,
+	/// Request ID
+	pub id: Option<Id>,
+	/// Name of the method to be invoked.
+	pub method: String,
+	/// Parameter values of the request.
+	pub params: Option<T>,
+}
+
+/// JSON-RPC Response object as defined in the [spec](https://www.jsonrpc.org/specification#request-object).
+/// TODO: Figure out a cleaner way to do this.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+#[serde(untagged)]
+pub enum Response<T, E> {
+    Ok(ResultResponse<T>),
+    Err(ErrorResponse<E>),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct ResultResponse<T> {
+	pub jsonrpc: String,
+	pub id: Id,
+	pub result: T,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct ErrorResponse<T> {
+	pub jsonrpc: String,
+	pub id: Id,
+	pub error: ErrorResponseError<T>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct ErrorResponseError<T> {
+    pub code: i64,
+    pub message: String,
+    pub data: Option<T>,
+}
+

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
 #[derive(Debug, PartialEq, Clone, Hash, Eq, Deserialize, Serialize, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 #[serde(untagged)]
 pub enum Id {
@@ -15,6 +16,7 @@ pub enum Id {
 
 /// JSON-RPC request object as defined in the [spec](https://www.jsonrpc.org/specification#request-object).
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct Request<T> {
     /// JSON-RPC version.
@@ -30,6 +32,7 @@ pub struct Request<T> {
 /// JSON-RPC Response object as defined in the [spec](https://www.jsonrpc.org/specification#request-object).
 /// TODO: Figure out a cleaner way to do this.
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 #[serde(untagged)]
 pub enum Response<T, E> {
@@ -38,6 +41,7 @@ pub enum Response<T, E> {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct ResultResponse<T> {
     pub jsonrpc: String,
@@ -46,6 +50,7 @@ pub struct ResultResponse<T> {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct ErrorResponse<T> {
     pub jsonrpc: String,
@@ -54,6 +59,7 @@ pub struct ErrorResponse<T> {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct ErrorResponseError<T> {
     pub code: i64,

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -1,30 +1,30 @@
-use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 
 #[derive(Debug, PartialEq, Clone, Hash, Eq, Deserialize, Serialize, PartialOrd, Ord)]
 #[serde(deny_unknown_fields)]
 #[serde(untagged)]
 pub enum Id {
-	/// Null
-	Null,
-	/// Numeric id
-	Number(u64),
-	/// String id
-	Str(String),
+    /// Null
+    Null,
+    /// Numeric id
+    Number(u64),
+    /// String id
+    Str(String),
 }
 
 /// JSON-RPC request object as defined in the [spec](https://www.jsonrpc.org/specification#request-object).
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Request<T> {
-	/// JSON-RPC version.
-	pub jsonrpc: String,
-	/// Request ID
-	pub id: Option<Id>,
-	/// Name of the method to be invoked.
-	pub method: String,
-	/// Parameter values of the request.
-	pub params: Option<T>,
+    /// JSON-RPC version.
+    pub jsonrpc: String,
+    /// Request ID
+    pub id: Option<Id>,
+    /// Name of the method to be invoked.
+    pub method: String,
+    /// Parameter values of the request.
+    pub params: Option<T>,
 }
 
 /// JSON-RPC Response object as defined in the [spec](https://www.jsonrpc.org/specification#request-object).
@@ -40,17 +40,17 @@ pub enum Response<T, E> {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ResultResponse<T> {
-	pub jsonrpc: String,
-	pub id: Id,
-	pub result: T,
+    pub jsonrpc: String,
+    pub id: Id,
+    pub result: T,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ErrorResponse<T> {
-	pub jsonrpc: String,
-	pub id: Id,
-	pub error: ErrorResponseError<T>,
+    pub jsonrpc: String,
+    pub id: Id,
+    pub error: ErrorResponseError<T>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -60,4 +60,3 @@ pub struct ErrorResponseError<T> {
     pub message: String,
     pub data: Option<T>,
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 mod deploy;
 mod inspect;
 mod invoke;
+mod serve;
 mod snapshot;
 mod strval;
 mod utils;
@@ -23,6 +24,8 @@ enum Cmd {
     Invoke(invoke::Cmd),
     /// Inspect a WASM file listing contract functions, meta, etc
     Inspect(inspect::Cmd),
+    /// Run a local webserver for web app development and testing
+    Serve(serve::Cmd),
     /// Deploy a WASM file as a contract
     Deploy(deploy::Cmd),
     /// Print version information
@@ -35,23 +38,27 @@ enum CmdError {
     Inspect(#[from] inspect::Error),
     #[error("invoke")]
     Invoke(#[from] invoke::Error),
+    #[error("serve")]
+    Serve(#[from] serve::Error),
     #[error("deploy")]
     Deploy(#[from] deploy::Error),
 }
 
-fn run(cmd: Cmd) -> Result<(), CmdError> {
+async fn run(cmd: Cmd) -> Result<(), CmdError> {
     match cmd {
         Cmd::Inspect(inspect) => inspect.run()?,
         Cmd::Invoke(invoke) => invoke.run()?,
+        Cmd::Serve(serve) => serve.run().await?,
         Cmd::Deploy(deploy) => deploy.run()?,
         Cmd::Version(version) => version.run(),
     };
     Ok(())
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let root = Root::parse();
-    if let Err(e) = run(root.cmd) {
+    if let Err(e) = run(root.cmd).await {
         eprintln!("error: {:?}", e);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{AppSettings, Parser, Subcommand};
 use thiserror::Error;
 
+mod contractspec;
 mod deploy;
 mod inspect;
 mod invoke;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 mod deploy;
 mod inspect;
 mod invoke;
+mod jsonrpc;
 mod serve;
 mod snapshot;
 mod strval;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,4 +1,13 @@
-use std::{fmt::Debug, fs, io, io::Cursor, sync::Arc, rc::Rc, path::PathBuf};
+use std::{
+    fmt::Debug,
+    fs,
+    io,
+    io::Cursor,
+    net::SocketAddr,
+    path::PathBuf,
+    rc::Rc,
+    sync::Arc,
+};
 
 use clap::Parser;
 use serde_json::{Value, json};
@@ -135,8 +144,10 @@ impl Cmd {
                 }
             });
 
+        let addr: SocketAddr = ([127, 0, 0, 1], self.port.unwrap_or(8080)).into();
+        println!("Listening on: {}", addr);
         warp::serve(call)
-            .run(([127, 0, 0, 1], self.port.unwrap_or(8080)))
+            .run(addr)
             .await;
         Ok(())
     }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,0 +1,235 @@
+use std::{fmt::Debug, fs, io, io::Cursor, sync::Arc, rc::Rc, path::PathBuf};
+
+use clap::Parser;
+use serde_json::{Value, json};
+use soroban_env_host::{
+    budget::CostType,
+    storage::Storage,
+    xdr::{
+        Error as XdrError, HostFunction, ReadXdr, WriteXdr, ScHostStorageErrorCode, ScObject, ScSpecEntry,
+        ScSpecFunctionV0, ScStatus, ScVal,
+    },
+    Host, HostError, Vm,
+};
+use warp::Filter;
+use hex::FromHexError;
+
+use crate::snapshot;
+use crate::invoke;
+use crate::strval::{self, StrValError};
+use crate::utils;
+
+#[derive(Parser, Debug)]
+pub struct Cmd {
+    /// WASM file to deploy to the contract ID and invoke
+    #[clap(long)]
+    port: Option<u16>,
+    /// File to persist ledger state
+    #[clap(long, parse(from_os_str), default_value("ledger.json"))]
+    ledger_file: PathBuf,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("io")]
+    Io(#[from] io::Error),
+    #[error("strval")]
+    StrVal(#[from] StrValError),
+    #[error("xdr")]
+    Xdr(#[from] XdrError),
+    #[error("host")]
+    Host(#[from] HostError),
+    #[error("snapshot")]
+    Snapshot(#[from] snapshot::Error),
+    #[error("serde")]
+    Serde(#[from] serde_json::Error),
+    #[error("hex")]
+    FromHex(#[from] FromHexError),
+    #[error("contractnotfound")]
+    FunctionNotFoundInContractSpec,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[serde(tag = "method", content = "params")]
+#[serde(rename_all = "snake_case")]
+enum Requests {
+    Call { id: String, func: String, args: Option<Vec<Value>>, args_xdr: Option<Vec<String>> },
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[serde(tag = "method", content = "params")]
+#[serde(rename_all = "snake_case")]
+enum Notifications {
+}
+
+#[derive(Debug)]
+enum JsonRpc<N, R> {
+    Request(usize, R),
+    Notification(N),
+}
+
+impl<N, R> serde::Serialize for JsonRpc<N, R>
+    where N: serde::Serialize,
+          R: serde::Serialize
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer
+    {
+        match *self {
+            JsonRpc::Request(id, ref r) => {
+                let mut v = serde_json::to_value(r).map_err(serde::ser::Error::custom)?;
+                v["id"] = json!(id);
+                v.serialize(serializer)
+            }
+            JsonRpc::Notification(ref n) => n.serialize(serializer),
+        }
+    }
+}
+
+impl<'de, N, R> serde::Deserialize<'de> for JsonRpc<N, R>
+    where N: serde::Deserialize<'de>,
+          R: serde::Deserialize<'de>
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: serde::Deserializer<'de>
+    {
+        #[derive(serde::Deserialize)]
+        struct IdHelper {
+            id: Option<usize>,
+        }
+
+        let v = Value::deserialize(deserializer)?;
+        let helper = IdHelper::deserialize(&v).map_err(serde::de::Error::custom)?;
+        match helper.id {
+            Some(id) => {
+                let r = R::deserialize(v).map_err(serde::de::Error::custom)?;
+                Ok(JsonRpc::Request(id, r))
+            }
+            None => {
+                let n = N::deserialize(v).map_err(serde::de::Error::custom)?;
+                Ok(JsonRpc::Notification(n))
+            }
+        }
+    }
+}
+
+type Request = JsonRpc<Notifications, Requests>;
+
+impl Cmd {
+    pub async fn run(&self) -> Result<(), Error> {
+        // let context = HostContext::default();
+        // eprintln!("Hello World!");
+        // process::exit(0);
+
+        let ledger_file = Arc::new(self.ledger_file.clone());
+        let with_ledger_file = warp::any().map(move || ledger_file.clone());
+
+        let call = warp::post()
+            .and(warp::path("rpc"))
+            .and(warp::body::json())
+            .and(with_ledger_file)
+            .map(|request: Requests, ledger_file: Arc<PathBuf>| match request {
+                Requests::Call { id, func, args, args_xdr } => {
+                    let lf = ledger_file.clone();
+                    reply(invoke(id, func, args.unwrap_or_default(), args_xdr.unwrap_or_default(), &lf))
+                }
+            });
+
+        warp::serve(call)
+            .run(([127, 0, 0, 1], self.port.unwrap_or(8080)))
+            .await;
+        Ok(())
+    }
+}
+
+fn reply(result: Result<ScVal, Error>) -> impl warp::Reply {
+    match result {
+        Ok(res) => {
+            let mut ret_xdr_buf: Vec<u8> = Vec::new();
+            match (strval::to_string(&res), res.write_xdr(&mut Cursor::new(&mut ret_xdr_buf))) {
+                (Ok(j), Ok(())) => json!({
+                    "result": {
+                        "json": j,
+                        "xdr": base64::encode(ret_xdr_buf),
+                    },
+                }).to_string(),
+                (Err(err), _) => reply(Err(Error::StrVal(err))),
+                (_, Err(err)) => reply(Err(Error::Xdr(err))),
+            }
+        }
+        Err(err) => {
+            json!({ "error": err.to_string() }).to_string()
+        }
+    }
+}
+
+fn invoke(contract: String, func: String, args: Vec<Value>, args_xdr: Vec<String>, ledger_file: &PathBuf) -> Result<ScVal, Error> {
+    let contract_id: [u8; 32] = utils::contract_id_from_str(&contract)?;
+
+    // Initialize storage and host
+    // TODO: allow option to separate input and output file
+    let ledger_entries = snapshot::read(ledger_file)?;
+
+    let snap = Rc::new(snapshot::Snap {
+        ledger_entries: ledger_entries.clone(),
+    });
+    let mut storage = Storage::with_recording_footprint(snap);
+    let contents = utils::get_contract_wasm_from_storage(&mut storage, contract_id)?;
+    let h = Host::with_storage(storage);
+
+    let vm = Vm::new(&h, [0; 32].into(), &contents).unwrap();
+    let input_types = match invoke::Cmd::function_spec(&vm, &func) {
+        Some(s) => s.input_types,
+        None => {
+            return Err(Error::FunctionNotFoundInContractSpec);
+        }
+    };
+
+    // re-assemble the args, to match the order given on the command line
+    let args: Vec<ScVal> = if args_xdr.is_empty() {
+        args
+            .iter()
+            .zip(input_types.iter())
+            .map(|(a, t)| strval::from_json(a, t))
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        args_xdr
+            .iter()
+            .map(|a| match base64::decode(a) {
+                Err(_) => Err(StrValError::InvalidValue),
+                Ok(b) => ScVal::from_xdr(b).map_err(StrValError::Xdr),
+            })
+            .collect::<Result<Vec<_>, _>>()?
+    };
+
+
+    let mut complete_args = vec![
+        ScVal::Object(Some(ScObject::Binary(contract_id.try_into()?))),
+        ScVal::Symbol((&func).try_into()?),
+    ];
+    complete_args.extend_from_slice(args.as_slice());
+
+    let res = h.invoke_function(HostFunction::Call, complete_args.try_into()?)?;
+
+    // TODO: Include costs in result struct
+    // let cost = h.get_budget(|b| {
+    //     let mut v = vec![
+    //         ("cpu_insns", b.cpu_insns.get_count()),
+    //         ("mem_bytes", b.mem_bytes.get_count()),
+    //     ];
+    //     // for cost_type in CostType::variants() {
+    //     //     v.push((cost_type.try_into()?, b.get_input(*cost_type)));
+    //     // }
+    //     Some(v)
+    // });
+
+    let storage = h.recover_storage().map_err(|_h| {
+        HostError::from(ScStatus::HostStorageError(
+            ScHostStorageErrorCode::UnknownError,
+        ))
+    })?;
+
+    snapshot::commit(ledger_entries, Some(&storage.map), ledger_file)?;
+
+    Ok(res)
+}


### PR DESCRIPTION
### What

Add `cli serve` command

It serves a jsonrpc API on `http://localhost:8080/rpc` which can be called with something like:
```sh
$ curl -v
    -X POST
    --header "content-type: application/json"
    http://localhost:8080/rpc
    --data-binary '{"jsonrpc":"2.0", "id":1, "method":"call", "params":{"id": "1", "func":"add", "args":[5, 3]}}'
```

This call command is similar to doing a cli invoke with:

```sh
$ cli invoke --contract 1 --fn add --arg 5 --arg 3
``` 

This is just a first pass at what the preflight request could look like. But it would need to include much more data in the response, so this will definitely change.

### Why

Fixes https://github.com/stellar/soroban-cli/issues/58

In particular, the idea is to let you run your dapp locally against the sandbox (The dev would do this separately). The API from `cli serve` should exactly match pubnet/futurenet. In one terminal/script you'd run `cli serve`, then in another you'd launch your web app server (e.g. `npm run dev`). As you click around in your browser the web app will submit txns and preflights to the cli server, simulating the real thing.

### Questions

- [ ] Should the `call` method be renamed to `invoke` to match the cli?
- [ ] Doesn't support submitting txns against the local sandbox, yet.
- [ ] Consider if/how to integrate this work with remote core backends instead of just local sandbox
- [ ] Consider how to share more code between this and the cli invoke subcommand.