### PR TITLE
Add links to Soroban Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 CLI for running Soroban contracts locally in a test VM. Executes WASM files built using the [rs-soroban-sdk](https://github.com/stellar/rs-soroban-sdk).
 
+Soroban: https://soroban.stellar.org
+
 ## Install
 
 ```
-cargo install soroban-cli
+cargo install --locked soroban-cli
 ```
 
 ## Usage

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,12 @@ mod utils;
 mod version;
 
 #[derive(Parser, Debug)]
-#[clap(version, about = "https://soroban.stellar.org", disable_help_subcommand = true, disable_version_flag = true)]
+#[clap(
+    version,
+    about = "https://soroban.stellar.org",
+    disable_help_subcommand = true,
+    disable_version_flag = true
+)]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 struct Root {
     #[clap(subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ mod utils;
 mod version;
 
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None, disable_help_subcommand = true, disable_version_flag = true)]
+#[clap(version, about = "https://soroban.stellar.org", disable_help_subcommand = true, disable_version_flag = true)]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 struct Root {
     #[clap(subcommand)]


### PR DESCRIPTION
### What
Add links to Soroban Docs and remove SDF from help output. Also add `--locked` to install command.

### Why
Having `Stellar Development Foundation <info@stellar.org>` in the output of the CLIs output isn't particularly helpful. If someone is having problems we don't want them to email `info@stellar.org`. Instead we should connect people with the docs.

It's relatively important to use `--locked` when installing, otherwise the lock file will be ignored and any just released software could be installed.