### PR TITLE
Add shell autocomplete using clap_complete crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ead064480dfc4880a10764488415a97fdd36a4cf1bb022d372f02e8faf8386e1"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1119,7 @@ version = "0.0.2"
 dependencies = [
  "base64",
  "clap",
+ "clap_complete",
  "hex",
  "num-bigint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ hex = "0.4.3"
 num-bigint = "0.4"
 tokio = { version = "1", features = ["full"] }
 warp = "0.3"
+clap_complete = "3.2.3"

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1,4 +1,4 @@
-use clap::{ArgEnum, Command, Parser};
+use clap::{Command, Parser};
 use clap_complete::{generate, Shell};
 use std::io;
 
@@ -18,29 +18,11 @@ To enable autocomplete permanently, run:
 pub struct Cmd {
     /// The shell type
     #[clap(long, arg_enum)]
-    shell: ShellType,
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ArgEnum, Debug)]
-enum ShellType {
-    Bash,
-    Zsh,
-    Fish,
-    Elvish,
-    #[clap(name = "powershell")]
-    PowerShell,
+    shell: Shell,
 }
 
 impl Cmd {
     pub fn run(&self, cmd: &mut Command) {
-        let gen = match self.shell {
-            ShellType::Bash => Shell::Bash,
-            ShellType::Zsh => Shell::Zsh,
-            ShellType::Fish => Shell::Fish,
-            ShellType::Elvish => Shell::Elvish,
-            ShellType::PowerShell => Shell::PowerShell,
-        };
-
-        generate(gen, cmd, env!("CARGO_PKG_NAME"), &mut io::stdout());
+        generate(self.shell, cmd, env!("CARGO_PKG_NAME"), &mut io::stdout());
     }
 }

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1,0 +1,46 @@
+use std::io;
+use clap::{ArgEnum, Command, Parser};
+use clap_complete::{Shell, generate};
+
+pub const LONG_ABOUT: &str = "\
+Print shell completion code for the specified shell
+
+Ensure the completion package for your shell is installed,
+e.g., bash-completion for bash.
+
+To enable autocomplete in the current bash shell, run:
+  source <(soroban-cli completion bash)
+  
+To enable autocomplete permanently, run:
+  echo \"source <(soroban-cli completion bash)\" >> ~/.bashrc";
+
+#[derive(Parser, Debug)]
+pub struct Cmd {
+    /// The shell type
+    #[clap(arg_enum, value_parser )]
+    shell: ShellType
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ArgEnum, Debug)]
+enum ShellType {
+    Bash,
+    Zsh,
+    Fish,
+    Elvish,
+    #[clap(name = "powershell")]
+    PowerShell
+}
+
+impl Cmd {
+    pub fn run(&self, cmd: &mut Command) {
+        let gen = match self.shell {
+            ShellType::Bash => Shell::Bash,
+            ShellType::Zsh => Shell::Zsh,
+            ShellType::Fish => Shell::Fish,
+            ShellType::Elvish => Shell::Elvish,
+            ShellType::PowerShell => Shell::PowerShell,
+        };
+
+        generate(gen, cmd, env!("CARGO_PKG_NAME"), &mut io::stdout())
+    }
+}

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1,6 +1,6 @@
-use std::io;
 use clap::{ArgEnum, Command, Parser};
-use clap_complete::{Shell, generate};
+use clap_complete::{generate, Shell};
+use std::io;
 
 pub const LONG_ABOUT: &str = "\
 Print shell completion code for the specified shell
@@ -17,8 +17,8 @@ To enable autocomplete permanently, run:
 #[derive(Parser, Debug)]
 pub struct Cmd {
     /// The shell type
-    #[clap(arg_enum, value_parser )]
-    shell: ShellType
+    #[clap(arg_enum, value_parser)]
+    shell: ShellType,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ArgEnum, Debug)]
@@ -28,7 +28,7 @@ enum ShellType {
     Fish,
     Elvish,
     #[clap(name = "powershell")]
-    PowerShell
+    PowerShell,
 }
 
 impl Cmd {
@@ -41,6 +41,6 @@ impl Cmd {
             ShellType::PowerShell => Shell::PowerShell,
         };
 
-        generate(gen, cmd, env!("CARGO_PKG_NAME"), &mut io::stdout())
+        generate(gen, cmd, env!("CARGO_PKG_NAME"), &mut io::stdout());
     }
 }

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -9,15 +9,15 @@ Ensure the completion package for your shell is installed,
 e.g., bash-completion for bash.
 
 To enable autocomplete in the current bash shell, run:
-  source <(soroban-cli completion bash)
-  
+  source <(soroban-cli completion --shell bash)
+
 To enable autocomplete permanently, run:
-  echo \"source <(soroban-cli completion bash)\" >> ~/.bashrc";
+  echo \"source <(soroban-cli completion --shell bash)\" >> ~/.bashrc";
 
 #[derive(Parser, Debug)]
 pub struct Cmd {
     /// The shell type
-    #[clap(arg_enum, value_parser)]
+    #[clap(long, arg_enum)]
     shell: ShellType,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{AppSettings, Parser, Subcommand};
+use clap::{AppSettings, Parser, Subcommand, CommandFactory};
 use thiserror::Error;
 
 mod contractspec;
@@ -11,6 +11,7 @@ mod snapshot;
 mod strval;
 mod utils;
 mod version;
+mod completion;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None, disable_help_subcommand = true, disable_version_flag = true)]
@@ -32,6 +33,9 @@ enum Cmd {
     Deploy(deploy::Cmd),
     /// Print version information
     Version(version::Cmd),
+    /// Print shell completion code for the specified shell.
+    #[clap(long_about = completion::LONG_ABOUT)]
+    Completion(completion::Cmd)
 }
 
 #[derive(Error, Debug)]
@@ -53,6 +57,7 @@ async fn run(cmd: Cmd) -> Result<(), CmdError> {
         Cmd::Serve(serve) => serve.run().await?,
         Cmd::Deploy(deploy) => deploy.run()?,
         Cmd::Version(version) => version.run(),
+        Cmd::Completion(completion) => completion.run(&mut Root::command()),
     };
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
-use clap::{AppSettings, Parser, Subcommand, CommandFactory};
+use clap::{AppSettings, CommandFactory, Parser, Subcommand};
 use thiserror::Error;
 
+mod completion;
 mod contractspec;
 mod deploy;
 mod inspect;
@@ -11,7 +12,6 @@ mod snapshot;
 mod strval;
 mod utils;
 mod version;
-mod completion;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None, disable_help_subcommand = true, disable_version_flag = true)]
@@ -35,7 +35,7 @@ enum Cmd {
     Version(version::Cmd),
     /// Print shell completion code for the specified shell.
     #[clap(long_about = completion::LONG_ABOUT)]
-    Completion(completion::Cmd)
+    Completion(completion::Cmd),
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
### What

This commit adds a `completion` subcommand that will generate autocomplete code for shells supported by `clap_complete`.

### Why

To enable users to enter commands and arguments more quickly and explore the CLI.

### Known limitations

N/A

### Usage & Testing

Build the CLI using `cargo build` then you should see the `completion` command after running `cargo run`. Running `cargo run completion --help` will display more detailed usage instructions.

To test the functionality run (for bash): `source <(cargo run completion bash)` and tab-completion for `soroban-cli` should be enabled in the current shell.

I've also been using an alias `sb` which can use completions by running `complete -o default -F _soroban-cli sb`.

If you use the suggested installation instructions in the `--help` completions should stay up-to-date with the `soroban-cli` if a new version is installed.

Closes #69 