### PR TITLE
Add ci workflow to set min rust-version

### DIFF
--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -1,0 +1,54 @@
+name: Rust Version
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 13 * * *'
+
+jobs:
+
+  check-and-update-rust-version:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update
+    - run: cargo install --locked --version 0.4.0 cargo-set-rust-version
+
+    # Update the rust-version in all workspace crates to the latest stable
+    # version.
+    - run: cargo set-rust-version
+
+    # Check if there is any diff resulting from updating the crates. If there is
+    # set the update=true output for following steps.
+    - id: diff
+      run: |
+        if ! git diff --exit-code; then
+          echo "::set-output name=update::true"
+        fi
+
+    # If the diff step indicates an update is required, create a branch and push
+    # it to GitHub. If the branch already exists with a change the push should
+    # fail, and so we shouldn't end up with multiple PRs.
+    - if: steps.diff.outputs.update == 'true'
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git checkout -b update-rust-version
+        git add .
+        git commit -m 'Update rust-version'
+        git push origin update-rust-version
+
+    # If the diff step indicates an update is required, open a PR.
+    - if: steps.diff.outputs.update == 'true'
+      name: Create Pull Request
+      uses: actions/github-script@v6
+      with:
+        script: |
+          await github.rest.pulls.create({
+            title: 'Update rust-version',
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            head: 'update-rust-version',
+            base: 'main',
+            body: '### What\nUpdate rust-version to latest stable.\n\n### Why\nTracking latest stable which receives security updates.'
+          });


### PR DESCRIPTION
### What
Add ci workflow to set min rust-version.

### Why
To set rust-version so that people see a meaningful error if they try to use an older version of rust-version.