### PR TITLE
Fix contract invoke

### DIFF
--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -88,7 +88,7 @@ impl Cmd {
         let contents = utils::get_contract_wasm_from_storage(&mut storage, contract_id)?;
         let h = Host::with_storage(storage);
 
-        let vm = Vm::new(&h, [0; 32].into(), &contents).unwrap();
+        let vm = Vm::new(&h, contract_id.into(), &contents).unwrap();
         let input_types = match contractspec::function_spec(&vm, &self.function) {
             Some(s) => s.input_types,
             None => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,8 @@ use soroban_env_host::{
     storage::Storage,
     xdr::{
         ContractDataEntry, Error as XdrError, LedgerEntry, LedgerEntryData, LedgerEntryExt,
-        LedgerKey, LedgerKeyContractData, ScObject, ScStatic, ScStatus, ScUnknownErrorCode, ScVal,
+        LedgerKey, LedgerKeyContractData, ScContractCode, ScObject, ScStatic, ScStatus,
+        ScUnknownErrorCode, ScVal,
     },
     HostError,
 };
@@ -22,7 +23,9 @@ pub fn add_contract_to_ledger_entries(
     let data = LedgerEntryData::ContractData(ContractDataEntry {
         contract_id: contract_id.into(),
         key: ScVal::Static(ScStatic::LedgerKeyContractCode),
-        val: ScVal::Object(Some(ScObject::Bytes(contract.try_into()?))),
+        val: ScVal::Object(Some(ScObject::ContractCode(ScContractCode::Wasm(
+            contract.try_into()?,
+        )))),
     });
 
     let entry = LedgerEntry {
@@ -51,7 +54,7 @@ pub fn get_contract_wasm_from_storage(
         key: ScVal::Static(ScStatic::LedgerKeyContractCode),
     });
     if let LedgerEntryData::ContractData(entry) = storage.get(&key)?.data {
-        if let ScVal::Object(Some(ScObject::Bytes(data))) = entry.val {
+        if let ScVal::Object(Some(ScObject::ContractCode(ScContractCode::Wasm(data)))) = entry.val {
             return Ok(data.to_vec());
         }
     }


### PR DESCRIPTION
### What
Update the storage of contract code in ledger.json to use the new ScContractCode XDR type.

### Why
The format for storing contracts was changed in the ledger, but the CLI has not yet been updated to match it, but is erroring when invoking contracts.

More reinforcement for why we need to add more tests to the CLI.