### PR TITLE
Add names to input types in spec functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,6 +1268,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.0.1"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=96d64bdd#96d64bdd49dd0f8e9099d3fae2fdb41f48d5d9ca"
 dependencies = [
  "base64",
  "darling",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=fba7071c#fba7071c55df509f3702b5074f9249749dae9a9b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7395b810#7395b8108b7eae28a2a068a0f3b75a5f824ee515"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -1221,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=fba7071c#fba7071c55df509f3702b5074f9249749dae9a9b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7395b810#7395b8108b7eae28a2a068a0f3b75a5f824ee515"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -1245,7 +1245,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=fba7071c#fba7071c55df509f3702b5074f9249749dae9a9b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7395b810#7395b8108b7eae28a2a068a0f3b75a5f824ee515"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1257,7 +1257,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=fba7071c#fba7071c55df509f3702b5074f9249749dae9a9b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7395b810#7395b8108b7eae28a2a068a0f3b75a5f824ee515"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1268,7 +1268,6 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=f814cb59#f814cb59d30a8c94a6bc53082ad297dfe33385a2"
 dependencies = [
  "base64",
  "darling",
@@ -1333,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=66436840#66436840ec4adcb871dac634d78568854b30dddb"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=f4fe3091#f4fe309136070c3d932bfcb8019ded953b842e5c"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,12 @@ clap_complete = "3.2.3"
 prettyplease = "0.1.18"
 syn = { version = "1.0.99", features = ["parsing"] }
 
+[patch."https://github.com/stellar/rs-soroban-sdk"]
+soroban-spec = { path = "../rs-soroban-sdk/soroban-spec" }
+
 [patch.crates-io]
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "fba7071c" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "fba7071c" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "fba7071c" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "fba7071c" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "66436840" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "f4fe3091" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.63"
 
 [dependencies]
 soroban-env-host = { version = "0.0.3", features = ["vm", "serde"] }
-soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "f814cb59" }
+soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "96d64bdd" }
 stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "99dfcf8" }
 clap = { version = "3.1.18", features = ["derive", "env"] }
 base64 = "0.13.0"
@@ -27,9 +27,6 @@ warp = "0.3"
 clap_complete = "3.2.3"
 prettyplease = "0.1.18"
 syn = { version = "1.0.99", features = ["parsing"] }
-
-[patch."https://github.com/stellar/rs-soroban-sdk"]
-soroban-spec = { path = "../rs-soroban-sdk/soroban-spec" }
 
 [patch.crates-io]
 soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "7395b810" }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -60,8 +60,8 @@ impl Cmd {
                     ScSpecEntry::FunctionV0(f) => println!(
                         " • Function: {} ({:?}) -> ({:?})",
                         f.name.to_string()?,
-                        f.input_types.as_slice(),
-                        f.output_types.as_slice(),
+                        f.inputs.as_slice(),
+                        f.outputs.as_slice(),
                     ),
                     ScSpecEntry::UdtUnionV0(udt) => {
                         println!(" • Union: {:?}", udt);

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -89,8 +89,8 @@ impl Cmd {
         let h = Host::with_storage(storage);
 
         let vm = Vm::new(&h, contract_id.into(), &contents).unwrap();
-        let input_types = match contractspec::function_spec(&vm, &self.function) {
-            Some(s) => s.input_types,
+        let inputs = match contractspec::function_spec(&vm, &self.function) {
+            Some(s) => s.inputs,
             None => {
                 return Err(Error::FunctionNotFoundInContractSpec);
             }
@@ -100,8 +100,8 @@ impl Cmd {
         let args: Vec<ScVal> = if self.args_xdr.is_empty() {
             self.args
                 .iter()
-                .zip(input_types.iter())
-                .map(|(a, t)| strval::from_string(a, t))
+                .zip(inputs.iter())
+                .map(|(a, input)| strval::from_string(a, &input.type_))
                 .collect::<Result<Vec<_>, _>>()?
         } else {
             self.args_xdr

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -185,8 +185,8 @@ fn invoke(
     let h = Host::with_storage(storage);
 
     let vm = Vm::new(&h, [0; 32].into(), &contents).unwrap();
-    let input_types = match contractspec::function_spec(&vm, func) {
-        Some(s) => s.input_types,
+    let inputs = match contractspec::function_spec(&vm, func) {
+        Some(s) => s.inputs,
         None => {
             return Err(Error::FunctionNotFoundInContractSpec);
         }
@@ -195,8 +195,8 @@ fn invoke(
     // re-assemble the args, to match the order given on the command line
     let args: Vec<ScVal> = if args_xdr.is_empty() {
         args.iter()
-            .zip(input_types.iter())
-            .map(|(a, t)| strval::from_json(a, t))
+            .zip(inputs.iter())
+            .map(|(a, input)| strval::from_json(a, &input.type_))
             .collect::<Result<Vec<_>, _>>()?
     } else {
         args_xdr


### PR DESCRIPTION
### What
Add names to input types in spec functions.

### Why
When defining an interface it is helpful to give names to the arguments of the functions so a user of the interface knows what to put in the arguments. This is especially helpful when multiple arguments have the same type, since a name is the only thing that distinguishes them.

Close stellar/rs-soroban-sdk#434