### PR TITLE
Use a parser independent of Vm/Host for inspecting wasm files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,6 +1205,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "warp",
+ "wasmparser 0.90.0",
 ]
 
 [[package]]
@@ -1279,7 +1280,7 @@ dependencies = [
  "stellar-xdr",
  "syn",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.88.0",
 ]
 
 [[package]]
@@ -1705,6 +1706,15 @@ name = "wasmparser"
 version = "0.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb8cf7dd82407fe68161bedcd57fde15596f32ebf6e9b3bdbf3ae1da20e38e5e"
+dependencies = [
+ "indexmap",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.90.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62c8d843f4423efee314dc75a1049886deba3214f7e7f9ff0e4e58b4d618581"
 dependencies = [
  "indexmap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ warp = "0.3"
 clap_complete = "3.2.3"
 prettyplease = "0.1.18"
 syn = { version = "1.0.99", features = ["parsing"] }
+wasmparser = "0.90.0"
 
 [patch.crates-io]
 soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "09dbeaaa" }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -37,11 +37,12 @@ impl Cmd {
         for payload in wasmparser::Parser::new(0).parse_all(&contents) {
             let payload = payload.map_err(Error::WasmParse)?;
             if let wasmparser::Payload::CustomSection(section) = payload {
-                match section.name() {
-                    "contractenvmetav0" => env_meta = Some(section.data()),
-                    "contractspecv0" => spec = Some(section.data()),
-                    _ => {}
-                }
+                let out = match section.name() {
+                    "contractenvmetav0" => &mut env_meta,
+                    "contractspecv0" => &mut spec,
+                    _ => continue,
+                };
+                *out = Some(section.data());
             };
         }
 

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use soroban_env_host::{
     xdr::{self, ReadXdr, ScEnvMetaEntry, ScSpecEntry},
-    Host, HostError, Vm,
+    HostError,
 };
 use std::{fmt::Debug, fs, io, io::Cursor, str::Utf8Error};
 
@@ -14,6 +14,8 @@ pub struct Cmd {
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("parse wasm")]
+    WasmParse(wasmparser::BinaryReaderError),
     #[error("xdr")]
     Xdr(#[from] xdr::Error),
     #[error("io")]
@@ -26,20 +28,24 @@ pub enum Error {
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
-        let contents = fs::read(&self.wasm)?;
-        let h = Host::default();
-        let vm = Vm::new(&h, [0; 32].into(), &contents)?;
         println!("File: {}", self.wasm.to_string_lossy());
-        println!("Functions:");
-        for f in vm.functions() {
-            println!(
-                " • {} ({}) -> ({})",
-                f.name,
-                vec!["val"; f.param_count].join(", "),
-                vec!["res"; f.result_count].join(", ")
-            );
+
+        let contents = fs::read(&self.wasm)?;
+
+        let mut spec: Option<&[u8]> = None;
+        let mut env_meta: Option<&[u8]> = None;
+        for payload in wasmparser::Parser::new(0).parse_all(&contents) {
+            let payload = payload.map_err(Error::WasmParse)?;
+            if let wasmparser::Payload::CustomSection(section) = payload {
+                match section.name() {
+                    "contractenvmetav0" => env_meta = Some(section.data()),
+                    "contractspecv0" => spec = Some(section.data()),
+                    _ => {}
+                }
+            };
         }
-        if let Some(env_meta) = vm.custom_section("contractenvmetav0") {
+
+        if let Some(env_meta) = env_meta {
             println!("Env Meta: {}", base64::encode(env_meta));
             let mut cursor = Cursor::new(env_meta);
             for env_meta_entry in ScEnvMetaEntry::read_xdr_iter(&mut cursor) {
@@ -52,7 +58,8 @@ impl Cmd {
         } else {
             println!("Env Meta: None");
         }
-        if let Some(spec) = vm.custom_section("contractspecv0") {
+
+        if let Some(spec) = spec {
             println!("Contract Spec: {}", base64::encode(spec));
             let mut cursor = Cursor::new(spec);
             for spec_entry in ScSpecEntry::read_xdr_iter(&mut cursor) {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -32,8 +32,8 @@ impl Cmd {
 
         let contents = fs::read(&self.wasm)?;
 
-        let mut spec: Option<&[u8]> = None;
         let mut env_meta: Option<&[u8]> = None;
+        let mut spec: Option<&[u8]> = None;
         for payload in wasmparser::Parser::new(0).parse_all(&contents) {
             let payload = payload.map_err(Error::WasmParse)?;
             if let wasmparser::Payload::CustomSection(section) = payload {


### PR DESCRIPTION
### What
Use a parser independent of Vm/Host for inspecting wasm files.

### Why
@graydon pointed out that we can't inspect files that are not compatible with the current Vm, which makes debugging when we have old files really difficult. The inspect command should work really with any file over time. We're using the `wasmparser` crate to parse wasm files in the SDK macros, using it here is simple. Maybe at some point we can consolidate this logic into a wasm utilities crate, although it feels a little premature to do so right now.

Close https://github.com/stellar/rs-soroban-sdk/issues/447