### PR TITLE
Check if rust-analyzer can parse project

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, build-and-test]
+    needs: [fmt, rust-analyzer-compat, build-and-test]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -24,6 +24,15 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update
     - run: cargo fmt --all --check
+
+  rust-analyzer-compat:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update
+    - run: rustup +nightly component add rust-analyzer
+    - name: Check if rust-analyzer encounters any errors parsing project
+      run: rustup run nightly rust-analyzer analysis-stats . 2>&1 | (! grep ERROR)
 
   build-and-test:
     strategy:


### PR DESCRIPTION
### What
Add ci job that checks if rust-analyzer can parse project.

### Why
A couple times now we have done things that are technically allowed in Rust but are not supported by rust-analyzer. Everytime we've walked the change back because rust-analyzer compatibility is important for developer productivity. Let's prevent these things from happening by checking if rust-analyzer can parse the project.

Same as https://github.com/stellar/rs-soroban-env/pull/371.