### PR TITLE
Add json output option for gen command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7978f95#7978f954bfd998e2836c4545f8746231be595e30"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7978f95#7978f954bfd998e2836c4545f8746231be595e30"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7978f95#7978f954bfd998e2836c4545f8746231be595e30"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1258,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7978f95#7978f954bfd998e2836c4545f8746231be595e30"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e0de03f#e0de03fe4b92831bfc8ed665d5ed86b109774f7f"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=9a11a63a#9a11a63ae9933ee4d0378d54be83257d8e76284e"
 dependencies = [
  "base64",
  "darling",
@@ -1338,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=61de11d#61de11d0ce5eb8a6e722d903af2abfadb5f5bd0e"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=4cb9c591#4cb9c5910a075386a440e57f26710bd6c0a4b3aa"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,14 +1268,18 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=96d64bdd#96d64bdd49dd0f8e9099d3fae2fdb41f48d5d9ca"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e0de03f#e0de03fe4b92831bfc8ed665d5ed86b109774f7f"
 dependencies = [
  "base64",
  "darling",
  "itertools",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
  "sha2 0.10.2",
+ "soroban-env-host",
  "stellar-xdr",
  "syn",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.63"
 
 [dependencies]
 soroban-env-host = { version = "0.0.3", features = ["vm", "serde"] }
-soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "e0de03f" }
+soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "9a11a63a" }
 stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "99dfcf8" }
 clap = { version = "3.1.18", features = ["derive", "env"] }
 base64 = "0.13.0"
@@ -31,8 +31,8 @@ wasmparser = "0.90.0"
 sha2 = "0.10.2"
 
 [patch.crates-io]
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "7978f95" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "7978f95" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "7978f95" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "7978f95" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "61de11d" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "4cb9c591" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.63"
 
 [dependencies]
 soroban-env-host = { version = "0.0.3", features = ["vm", "serde"] }
-soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "96d64bdd" }
+soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "e0de03f" }
 stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "99dfcf8" }
 clap = { version = "3.1.18", features = ["derive", "env"] }
 base64 = "0.13.0"

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -1,7 +1,11 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, fs, io, io::Cursor};
 
 use clap::{ArgEnum, Parser};
-use soroban_spec::gen::rust;
+use soroban_env_host::{
+    xdr::{ReadXdr, ScSpecEntry},
+    Host, HostError, Vm,
+};
+use soroban_spec::gen::{json, rust};
 
 #[derive(Parser, Debug)]
 pub struct Cmd {
@@ -17,38 +21,59 @@ pub struct Cmd {
 pub enum Output {
     /// Rust trait, client bindings, and test harness
     Rust,
+    /// Json representation of contract spec types
+    Json,
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("generate rust from file: {0}")]
-    GenerateRustFromFile(rust::GenerateFromFileError),
+    GenerateRustFromFile(#[from] rust::GenerateFromFileError),
     #[error("format rust error: {0}")]
-    FormatRustError(syn::Error),
+    FormatRust(#[from] syn::Error),
+    #[error("host")]
+    Host(#[from] HostError),
+    #[error("xdr error: {0}")]
+    Xdr(#[from] soroban_env_host::xdr::Error),
+    #[error("io")]
+    Io(#[from] io::Error),
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("contractnotfound")]
+    ContractSpecNotFound,
 }
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
         match self.output {
             Output::Rust => self.generate_rust(),
+            Output::Json => self.generate_json(),
         }
     }
 
     pub fn generate_rust(&self) -> Result<(), Error> {
         let wasm_path_str = self.wasm.to_string_lossy();
-        let code =
-            rust::generate_from_file(&wasm_path_str, None).map_err(Error::GenerateRustFromFile)?;
+        let code = rust::generate_from_file(&wasm_path_str, None)?;
         let code_raw = code.to_string();
-        match syn::parse_file(&code_raw) {
-            Ok(file) => {
-                let code_fmt = prettyplease::unparse(&file);
-                println!("{}", code_fmt);
-                Ok(())
+        let code_fmt = prettyplease::unparse(&syn::parse_file(&code_raw)?);
+        println!("{}", code_fmt);
+        Ok(())
+    }
+
+    pub fn generate_json(&self) -> Result<(), Error> {
+        let contents = fs::read(&self.wasm)?;
+        let h = Host::default();
+        let vm = Vm::new(&h, [0; 32].into(), &contents)?;
+
+        if let Some(spec) = vm.custom_section("contractspecv0") {
+            let mut cursor = Cursor::new(spec);
+            for spec_entry in ScSpecEntry::read_xdr_iter(&mut cursor) {
+                let spec_json = json::Entry::try_from(&spec_entry?)?;
+                println!("{}", serde_json::to_string(&spec_json)?);
             }
-            Err(e) => {
-                println!("{}", code_raw);
-                Err(Error::FormatRustError(e))
-            }
+        } else {
+            return Err(Error::ContractSpecNotFound);
         }
+        Ok(())
     }
 }


### PR DESCRIPTION
### What

There is an existing `gen` command which currently generates rust bindings for a soroban smart contract. This PR adds an option to generate a JSON representation for a soroban smart contract spec.

### Why

Fixes https://github.com/stellar/soroban-cli/issues/56

### Known limitations

[N/A]
