### PR TITLE
Add BytesN support to spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7978f95#7978f954bfd998e2836c4545f8746231be595e30"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7978f95#7978f954bfd998e2836c4545f8746231be595e30"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7978f95#7978f954bfd998e2836c4545f8746231be595e30"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1258,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7978f95#7978f954bfd998e2836c4545f8746231be595e30"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=823711e4#823711e40b48b5d211ee17c63d886ecefe936c48"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1269,14 +1269,18 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=96d64bdd#96d64bdd49dd0f8e9099d3fae2fdb41f48d5d9ca"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=518a1456#518a145605a2591d181a24b31e45039d280eca13"
 dependencies = [
  "base64",
  "darling",
  "itertools",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
  "sha2 0.10.2",
+ "soroban-env-host",
  "stellar-xdr",
  "syn",
  "thiserror",
@@ -1334,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=61de11d#61de11d0ce5eb8a6e722d903af2abfadb5f5bd0e"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=4cb9c591#4cb9c5910a075386a440e57f26710bd6c0a4b3aa"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.63"
 
 [dependencies]
 soroban-env-host = { version = "0.0.3", features = ["vm", "serde"] }
-soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "96d64bdd" }
+soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "518a1456" }
 stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "99dfcf8" }
 clap = { version = "3.1.18", features = ["derive", "env"] }
 base64 = "0.13.0"
@@ -31,8 +31,8 @@ wasmparser = "0.90.0"
 sha2 = "0.10.2"
 
 [patch.crates-io]
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "7978f95" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "7978f95" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "7978f95" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "7978f95" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "61de11d" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "823711e4" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "4cb9c591" }


### PR DESCRIPTION
### What
Add BytesN support to spec.

### Why
So that functions that accept BytesN can be generated as such.

Close stellar/stellar-xdr-next#15