### PR TITLE
Improve invoke error reporting

### DIFF
--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -85,7 +85,7 @@ pub enum Error {
     },
     #[error("function name {0} is too long")]
     FunctionNameTooLong(String),
-    #[error("argument count ({current}) surpasses maximum count ({maximum})")]
+    #[error("argument count ({current}) surpasses maximum allowed count ({maximum})")]
     MaxNumberOfArgumentsReached { current: usize, maximum: usize },
     #[error("cannot print result {result:?}: {error}")]
     CannotPrintResult { result: ScVal, error: StrValError },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use clap::{AppSettings, CommandFactory, FromArgMatches, Parser, Subcommand};
-use thiserror::Error;
 
 mod completion;
 mod contractspec;
@@ -51,19 +50,20 @@ enum Cmd {
     Completion(completion::Cmd),
 }
 
-#[derive(Error, Debug)]
+#[derive(thiserror::Error, Debug)]
 enum CmdError {
-    #[error("inspect")]
+    // TODO: stop using Debug for displaying errors
+    #[error("{0:?}")]
     Inspect(#[from] inspect::Error),
-    #[error("invoke")]
+    #[error(transparent)]
     Invoke(#[from] invoke::Error),
-    #[error("read")]
+    #[error("{0:?}")]
     Read(#[from] read::Error),
-    #[error("serve")]
+    #[error("{0:?}")]
     Serve(#[from] serve::Error),
-    #[error("gen")]
+    #[error("{0:?}")]
     Gen(#[from] gen::Error),
-    #[error("deploy")]
+    #[error("{0:?}")]
     Deploy(#[from] deploy::Error),
 }
 
@@ -99,6 +99,6 @@ async fn main() {
     };
 
     if let Err(e) = run(root.cmd, &mut saved_matches).await {
-        eprintln!("error: {:?}", e);
+        eprintln!("error: {}", e);
     }
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -9,13 +9,13 @@ use soroban_env_host::{
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("io")]
+    #[error(transparent)]
     Io(#[from] io::Error),
-    #[error("xdr")]
+    #[error(transparent)]
     Xdr(#[from] XdrError),
-    #[error("host")]
+    #[error(transparent)]
     Host(#[from] HostError),
-    #[error("serde")]
+    #[error(transparent)]
     Serde(#[from] serde_json::Error),
 }
 
@@ -43,7 +43,7 @@ pub fn read(input_file: &std::path::PathBuf) -> Result<OrdMap<LedgerKey, LedgerE
         Ok(f) => f,
         Err(e) => {
             //File doesn't exist, so treat this as an empty database and the file will be created later
-            if e.kind() == std::io::ErrorKind::NotFound {
+            if e.kind() == io::ErrorKind::NotFound {
                 return Ok(res);
             }
             return Err(Error::Io(e));


### PR DESCRIPTION
### What

Improve the error reporting of the `invoke` subcommand.

### Why

We used to print the internal (Debug) representation of the error data structures, which is not very helpful for the end user. 

### Known limitations

We still need to implement the same for the other subcommands.


Comment for reviewers: it seems like creating a type with every possible error is really verbose, which makes me think it may not be very idiomatic.

Coming from Golang I was tempted to create errors from strings, but maybe this is just the price to pay in order to have structured errors?