### PR TITLE
Fix wasm file not found error

### DIFF
--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -167,7 +167,7 @@ impl Cmd {
         //If a file is specified, deploy the contract to storage
         if let Some(f) = &self.wasm {
             let contract = fs::read(f).map_err(|e| Error::CannotReadContractFile {
-                filepath: self.ledger_file.clone(),
+                filepath: f.clone(),
                 error: e,
             })?;
             utils::add_contract_to_ledger_entries(&mut ledger_entries, contract_id, contract)


### PR DESCRIPTION
### What
Change the error message for when the wasm file has a read error to output the name of the wasm file instead of the ledger file.

### Why
It is the wasm file that has the issue, so we should include it in the error message rather than the ledger file.