### PR TITLE
Print event at the end of invocation

### DIFF
--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -3,6 +3,7 @@ use std::{fmt::Debug, fs, io, rc::Rc};
 use clap::Parser;
 use soroban_env_host::{
     budget::{Budget, CostType},
+    events::HostEvent,
     storage::Storage,
     xdr::{
         Error as XdrError, HostFunction, ReadXdr, ScHostStorageErrorCode, ScObject,
@@ -229,8 +230,13 @@ impl Cmd {
                 eprintln!("Cost ({:?}): {}", cost_type, budget.get_input(*cost_type));
             }
         }
-        if !events.0.is_empty() {
-            eprintln!("Events: {:?}", events);
+
+        for (i, event) in events.0.iter().enumerate() {
+            eprintln!("Event #{}:", i);
+            match event {
+                HostEvent::Contract(e) => eprint!("{}", serde_json::to_string_pretty(&e).unwrap()),
+                HostEvent::Debug(e) => eprint!("{}", e),
+            }
         }
 
         snapshot::commit(ledger_entries, &storage.map, &self.ledger_file).map_err(|e| {

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -234,7 +234,7 @@ impl Cmd {
         for (i, event) in events.0.iter().enumerate() {
             eprintln!("Event #{}:", i);
             match event {
-                HostEvent::Contract(e) => eprint!("{}", serde_json::to_string_pretty(&e).unwrap()),
+                HostEvent::Contract(e) => eprint!("{}", serde_json::to_string(&e).unwrap()),
                 HostEvent::Debug(e) => eprint!("{}", e),
             }
         }

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -216,7 +216,7 @@ impl Cmd {
         })?;
         println!("{}", res_str);
 
-        let (storage, budget, _) = h.try_finish().map_err(|_h| {
+        let (storage, budget, events) = h.try_finish().map_err(|_h| {
             HostError::from(ScStatus::HostStorageError(
                 ScHostStorageErrorCode::UnknownError,
             ))
@@ -228,6 +228,9 @@ impl Cmd {
             for cost_type in CostType::variants() {
                 eprintln!("Cost ({:?}): {}", cost_type, budget.get_input(*cost_type));
             }
+        }
+        if !events.0.is_empty() {
+            eprintln!("Events: {:?}", events);
         }
 
         snapshot::commit(ledger_entries, &storage.map, &self.ledger_file).map_err(|e| {


### PR DESCRIPTION
### What

Add a print statement at the end to print out the `events` from `host`.  cc @sisuresh 

### Why

To make the contract event example more meaningful. It's much better to show the event being printed than describing it as part of the host that can be retrieved. 

### Known limitations

The print relies on the `Debug` trait of `xdr::ContractEvent`, which isn't pretty. We might want to add the proper `Display` impl of it at the `xdrgen` later. 
