### PR TITLE
Add support for hex strvals to Bytes/BytesN

### DIFF
--- a/src/strval.rs
+++ b/src/strval.rs
@@ -9,6 +9,8 @@ use soroban_env_host::xdr::{
 
 use stellar_strkey::StrkeyPublicKeyEd25519;
 
+use crate::utils;
+
 #[derive(Debug)]
 pub enum StrValError {
     UnknownError,
@@ -66,19 +68,13 @@ pub fn from_string(s: &str, t: &ScSpecTypeDef) -> Result<ScVal, StrValError> {
                 _ =>
                 // it could be a G- strkey
                 {
-                    match StrkeyPublicKeyEd25519::from_string(s) {
-                        Ok(key) => {
-                            let b = &key.0;
-                            ScVal::Object(Some(ScObject::Bytes(
-                                b.try_into().map_err(|_| StrValError::InvalidValue)?,
-                            )))
-                        }
-                        // just grab the bytes
-                        Err(_) => ScVal::Object(Some(ScObject::Bytes(
-                            s.as_bytes()
-                                .try_into()
-                                .map_err(|_| StrValError::InvalidValue)?,
-                        ))),
+                    if let Ok(key) = StrkeyPublicKeyEd25519::from_string(s) {
+                        let b = &key.0;
+                        ScVal::Object(Some(ScObject::Bytes(
+                            b.try_into().map_err(|_| StrValError::InvalidValue)?,
+                        )))
+                    } else {
+                        from_json(&Value::String(s.to_string()), t)?
                     }
                 }
             }
@@ -178,14 +174,19 @@ pub fn from_json(v: &Value, t: &ScSpecTypeDef) -> Result<ScVal, StrValError> {
                 .map_err(|_| StrValError::InvalidValue)?,
         ),
 
-        // Binary parsing
-        (ScSpecTypeDef::Bytes | ScSpecTypeDef::BytesN(_), Value::String(s)) => {
-            ScVal::Object(Some(ScObject::Bytes(
-                s.as_bytes()
-                    .try_into()
-                    .map_err(|_| StrValError::InvalidValue)?,
-            )))
-        }
+        // Bytes parsing
+        (ScSpecTypeDef::BytesN(bytes), Value::String(s)) => ScVal::Object(Some(ScObject::Bytes(
+            utils::padded_hex_from_str(s, bytes.n as usize)
+                .map_err(|_| StrValError::InvalidValue)?
+                .try_into()
+                .map_err(|_| StrValError::InvalidValue)?,
+        ))),
+        (ScSpecTypeDef::Bytes, Value::String(s)) => ScVal::Object(Some(ScObject::Bytes(
+            hex::decode(s)
+                .map_err(|_| StrValError::InvalidValue)?
+                .try_into()
+                .map_err(|_| StrValError::InvalidValue)?,
+        ))),
         (ScSpecTypeDef::Bytes | ScSpecTypeDef::BytesN(_), Value::Array(raw)) => {
             let b: Result<Vec<u8>, StrValError> = raw
                 .iter()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -38,11 +38,17 @@ pub fn add_contract_to_ledger_entries(
     Ok(())
 }
 
-pub fn contract_id_from_str(contract_id: &String) -> Result<[u8; 32], FromHexError> {
-    let mut decoded = [0u8; 32];
-    let padded = format!("{:0>width$}", contract_id, width = decoded.len() * 2);
+pub fn padded_hex_from_str(s: &String, n: usize) -> Result<Vec<u8>, FromHexError> {
+    let mut decoded = vec![0u8; n];
+    let padded = format!("{:0>width$}", s, width = n * 2);
     hex::decode_to_slice(padded, &mut decoded)?;
     Ok(decoded)
+}
+
+pub fn contract_id_from_str(contract_id: &String) -> Result<[u8; 32], FromHexError> {
+    padded_hex_from_str(contract_id, 32)?
+        .try_into()
+        .map_err(|_| FromHexError::InvalidStringLength)
 }
 
 pub fn get_contract_wasm_from_storage(


### PR DESCRIPTION
### What
Add support for hex strvals to Bytes/BytesN.

### Why
So that people can type bytes as hex in addition to the existing formats of G strkeys and JSON number arrays.