### PR TITLE
Set and store LedgerInfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.4"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=3e9bd46#3e9bd4632c9a5b860d1e961f2fb9645a8b2dceca"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5201a9#f5201a9683965906e4dbc609768e181fb66526f7"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.4"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=3e9bd46#3e9bd4632c9a5b860d1e961f2fb9645a8b2dceca"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5201a9#f5201a9683965906e4dbc609768e181fb66526f7"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.4"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=3e9bd46#3e9bd4632c9a5b860d1e961f2fb9645a8b2dceca"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5201a9#f5201a9683965906e4dbc609768e181fb66526f7"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1258,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.4"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=3e9bd46#3e9bd4632c9a5b860d1e961f2fb9645a8b2dceca"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5201a9#f5201a9683965906e4dbc609768e181fb66526f7"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.4"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c8bc71d#c8bc71d530ad912c2b4129ca60be4348db22b287"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=3e9bd46#3e9bd4632c9a5b860d1e961f2fb9645a8b2dceca"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.4"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c8bc71d#c8bc71d530ad912c2b4129ca60be4348db22b287"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=3e9bd46#3e9bd4632c9a5b860d1e961f2fb9645a8b2dceca"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.4"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c8bc71d#c8bc71d530ad912c2b4129ca60be4348db22b287"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=3e9bd46#3e9bd4632c9a5b860d1e961f2fb9645a8b2dceca"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1258,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.4"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c8bc71d#c8bc71d530ad912c2b4129ca60be4348db22b287"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=3e9bd46#3e9bd4632c9a5b860d1e961f2fb9645a8b2dceca"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ sha2 = "0.10.2"
 [patch.crates-io]
 soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "ad77b1f" }
 stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "317f7689" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "3e9bd46" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "3e9bd46" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "3e9bd46" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "3e9bd46" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "f5201a9" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "f5201a9" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "f5201a9" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "f5201a9" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "fee9a43" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ sha2 = "0.10.2"
 [patch.crates-io]
 soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "ad77b1f" }
 stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "317f7689" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "c8bc71d" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "c8bc71d" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "c8bc71d" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "c8bc71d" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "3e9bd46" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "3e9bd46" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "3e9bd46" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "3e9bd46" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "fee9a43" }

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use hex::FromHexError;
 use soroban_env_host::{xdr::Error as XdrError, HostError};
 
-use crate::snapshot;
+use crate::snapshot::{self, get_default_ledger_info};
 use crate::utils;
 
 #[derive(Parser, Debug)]
@@ -62,19 +62,19 @@ impl Cmd {
             error: e,
         })?;
 
-        let mut ledger_entries =
+        let mut state =
             snapshot::read(&self.ledger_file).map_err(|e| Error::CannotReadLedgerFile {
                 filepath: self.ledger_file.clone(),
                 error: e,
             })?;
-        utils::add_contract_to_ledger_entries(&mut ledger_entries, contract_id, contract)?;
+        utils::add_contract_to_ledger_entries(&mut state.1, contract_id, contract)?;
 
-        snapshot::commit(ledger_entries, [], &self.ledger_file).map_err(|e| {
-            Error::CannotCommitLedgerFile {
+        snapshot::commit(state.1, get_default_ledger_info(), [], &self.ledger_file).map_err(
+            |e| Error::CannotCommitLedgerFile {
                 filepath: self.ledger_file.clone(),
                 error: e,
-            }
-        })?;
+            },
+        )?;
         Ok(())
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -103,13 +103,14 @@ impl Cmd {
         };
 
         // Initialize storage
-        let ledger_entries =
-            snapshot::read(&self.ledger_file).map_err(|e| Error::CannotReadLedgerFile {
-                filepath: self.ledger_file.clone(),
-                error: e,
-            })?;
+        let state = snapshot::read(&self.ledger_file).map_err(|e| Error::CannotReadLedgerFile {
+            filepath: self.ledger_file.clone(),
+            error: e,
+        })?;
 
-        let snap = Rc::new(snapshot::Snap { ledger_entries });
+        let snap = Rc::new(snapshot::Snap {
+            ledger_entries: state.1,
+        });
         let mut storage = Storage::with_recording_footprint(snap);
         let ledger_entry = storage.get(&LedgerKey::ContractData(LedgerKeyContractData {
             contract_id: xdr::Hash(contract_id),

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4,7 +4,7 @@ use soroban_env_host::{
     im_rc::OrdMap,
     storage::SnapshotSource,
     xdr::{Error as XdrError, LedgerEntry, LedgerKey, ScHostStorageErrorCode, ScStatus, VecM},
-    HostError,
+    HostError, LedgerInfo,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -23,6 +23,25 @@ pub struct Snap {
     pub ledger_entries: OrdMap<LedgerKey, LedgerEntry>,
 }
 
+pub fn get_default_ledger_info() -> LedgerInfo {
+    LedgerInfo {
+        protocol_version: 19,
+        sequence_number: 0,
+        timestamp: 0,
+        network_id: vec![0u8],
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SerializableState {
+    pub ledger_entries: VecM<(LedgerKey, LedgerEntry)>,
+    pub protocol_version: u32,
+    pub sequence_number: u32,
+    pub timestamp: u64,
+    pub network_id: Vec<u8>,
+}
+
 impl SnapshotSource for Snap {
     fn get(&self, key: &LedgerKey) -> Result<LedgerEntry, HostError> {
         match self.ledger_entries.get(key) {
@@ -36,28 +55,36 @@ impl SnapshotSource for Snap {
 }
 
 // Ledger file format is the default serde JSON representation of VecM<(LedgerKey, LedgerEntry)>
-pub fn read(input_file: &std::path::PathBuf) -> Result<OrdMap<LedgerKey, LedgerEntry>, Error> {
-    let mut res = OrdMap::new();
+pub fn read(
+    input_file: &std::path::PathBuf,
+) -> Result<(LedgerInfo, OrdMap<LedgerKey, LedgerEntry>), Error> {
+    let mut entries = OrdMap::new();
 
     let mut file = match File::open(input_file) {
         Ok(f) => f,
         Err(e) => {
             //File doesn't exist, so treat this as an empty database and the file will be created later
             if e.kind() == io::ErrorKind::NotFound {
-                return Ok(res);
+                return Ok((get_default_ledger_info(), entries));
             }
             return Err(Error::Io(e));
         }
     };
 
-    let state: VecM<(LedgerKey, LedgerEntry)> = serde_json::from_reader(&mut file)?;
-    res = state.iter().cloned().collect();
-
-    Ok(res)
+    let state: SerializableState = serde_json::from_reader(&mut file)?;
+    entries = state.ledger_entries.iter().cloned().collect();
+    let info = LedgerInfo {
+        protocol_version: state.protocol_version,
+        sequence_number: state.sequence_number,
+        timestamp: state.timestamp,
+        network_id: state.network_id,
+    };
+    Ok((info, entries))
 }
 
 pub fn commit<'a, I>(
     mut new_state: OrdMap<LedgerKey, LedgerEntry>,
+    ledger_info: LedgerInfo,
     storage_map: I,
     output_file: &std::path::PathBuf,
 ) -> Result<(), Error>
@@ -82,7 +109,15 @@ where
 
     let vec_new_state: VecM<(LedgerKey, LedgerEntry)> =
         new_state.into_iter().collect::<Vec<_>>().try_into()?;
-    serde_json::to_writer(&file, &vec_new_state)?;
+
+    let output = SerializableState {
+        ledger_entries: vec_new_state,
+        protocol_version: ledger_info.protocol_version,
+        sequence_number: ledger_info.sequence_number,
+        timestamp: ledger_info.timestamp,
+        network_id: ledger_info.network_id,
+    };
+    serde_json::to_writer(&file, &output)?;
 
     Ok(())
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -28,7 +28,7 @@ pub fn get_default_ledger_info() -> LedgerInfo {
         protocol_version: 19,
         sequence_number: 0,
         timestamp: 0,
-        network_id: vec![0u8],
+        network_passphrase: vec![0u8],
     }
 }
 
@@ -39,7 +39,7 @@ pub struct SerializableState {
     pub protocol_version: u32,
     pub sequence_number: u32,
     pub timestamp: u64,
-    pub network_id: Vec<u8>,
+    pub network_passphrase: Vec<u8>,
 }
 
 impl SnapshotSource for Snap {
@@ -77,7 +77,7 @@ pub fn read(
         protocol_version: state.protocol_version,
         sequence_number: state.sequence_number,
         timestamp: state.timestamp,
-        network_id: state.network_id,
+        network_passphrase: state.network_passphrase,
     };
     Ok((info, entries))
 }
@@ -115,7 +115,7 @@ where
         protocol_version: ledger_info.protocol_version,
         sequence_number: ledger_info.sequence_number,
         timestamp: ledger_info.timestamp,
-        network_id: ledger_info.network_id,
+        network_passphrase: ledger_info.network_passphrase,
     };
     serde_json::to_writer(&file, &output)?;
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -7,6 +7,8 @@ use soroban_env_host::{
     HostError, LedgerInfo,
 };
 
+use crate::network::SANDBOX_NETWORK_PASSPHRASE;
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
@@ -28,7 +30,7 @@ pub fn get_default_ledger_info() -> LedgerInfo {
         protocol_version: 19,
         sequence_number: 0,
         timestamp: 0,
-        network_passphrase: vec![0u8],
+        network_passphrase: SANDBOX_NETWORK_PASSPHRASE.as_bytes().to_vec(),
     }
 }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -36,12 +36,12 @@ pub fn get_default_ledger_info() -> LedgerInfo {
 
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SerializableState {
-    pub ledger_entries: VecM<(LedgerKey, LedgerEntry)>,
-    pub protocol_version: u32,
-    pub sequence_number: u32,
-    pub timestamp: u64,
-    pub network_passphrase: Vec<u8>,
+struct SerializableState {
+    ledger_entries: VecM<(LedgerKey, LedgerEntry)>,
+    protocol_version: u32,
+    sequence_number: u32,
+    timestamp: u64,
+    network_passphrase: Vec<u8>,
 }
 
 impl SnapshotSource for Snap {


### PR DESCRIPTION
Resolves #116.

1. The contents of `LedgerInfo` are stored in `ledger.json`.
2. `timestamp` and `sequence_number` are incremented on `invoke` and `serve`.
3. The only way to update the `LedgerInfo` fields at the moment is to update the values at the end of `ledger.json` (Ex. `}},"ext":"v0"}]],"protocolVersion":19,"sequenceNumber":4,"timestamp":12,"networkId":[0]}`. I can add a `set_ledger_Info` command, but wanted to get input before I went that route.
