### PR TITLE
Add publish dry run to build on release branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,10 @@ jobs:
     - run: rustup target add ${{ matrix.target }}
     - run: cargo clippy --all-targets --target ${{ matrix.target }}
     - run: cargo test --target ${{ matrix.target }}
+    - if: startsWith(github.head_ref, 'release/')
+      uses: stellar/actions/rust-workspace-publish-dry-run@main
+      with:
+        cargo-package-options: --target ${{ matrix.target }}}
 
   publish:
     if: github.event_name == 'release'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
     - if: startsWith(github.head_ref, 'release/')
       uses: stellar/actions/rust-workspace-publish-dry-run@main
       with:
-        cargo-package-options: --target ${{ matrix.target }}}
+        cargo-package-options: --target ${{ matrix.target }}
 
   publish:
     if: github.event_name == 'release'


### PR DESCRIPTION
### What
Add publish dry run to build on release branches.

### Why
There is nothing that checks the release process will succeed before we perform the release, fixing problems after starting the publish process is painful. This will help catch problems earlier when we are bumping versions.