### PR TITLE
Forget vm before finishing host

### DIFF
--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -224,6 +224,10 @@ impl Cmd {
         })?;
         println!("{}", res_str);
 
+        // Tear down the vm -- it holds a reference to the host, and the host can't be finished while
+        // it is still alive.
+        std::mem::forget(vm);
+
         let (storage, budget, events) = h.try_finish().map_err(|_h| {
             HostError::from(ScStatus::HostStorageError(
                 ScHostStorageErrorCode::UnknownError,


### PR DESCRIPTION
A simple fix for the vm-holds-a-reference-to-host issue introduced with the recent wasmi upgrade