### PR TITLE
invoke: add --event and --event-file flags

### DIFF
--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -277,13 +277,13 @@ impl Cmd {
                     .append(true)
                     .open(f)
                     .map_err(|e| Error::CannotOpenEventsFile {
-                        filepath: f.to_path_buf(),
+                        filepath: f.clone(),
                         error: e,
                     })?;
                 out = Box::new(file);
             }
 
-            for event in events.0.iter() {
+            for event in events.0 {
                 let event_str = match event {
                     HostEvent::Contract(e) => serde_json::to_string(&e).unwrap(),
                     HostEvent::Debug(e) => format!("{}", e),


### PR DESCRIPTION
### What

Add new event-related flags to the invoke subcommand:

* --events: enable printing host/debug events
* --events-file: write events to a file instead of stdout

### Why

1. Close #128
2. Enable saving events to a file/pipe which in turn will be used by `soroban-cli serve` to subscribe to local events (a new, matching `--events-file` flag will be added to to `sorobab-cli serve` for that purpose). This is part of https://github.com/stellar/soroban-cli/issues/39

### Known limitations

N/A
