### PR TITLE
Fix output logs of events

### DIFF
--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -251,10 +251,10 @@ impl Cmd {
         }
 
         for (i, event) in events.0.iter().enumerate() {
-            eprintln!("Event #{}:", i);
+            eprint!("Event #{}: ", i);
             match event {
-                HostEvent::Contract(e) => eprint!("{}", serde_json::to_string(&e).unwrap()),
-                HostEvent::Debug(e) => eprint!("{}", e),
+                HostEvent::Contract(e) => eprintln!("{}", serde_json::to_string(&e).unwrap()),
+                HostEvent::Debug(e) => eprintln!("{}", e),
             }
         }
 


### PR DESCRIPTION
### What
Put the `Event #n:` prefix of event logs onto the same line as the event they relate to.

### Why
They are currently printing on the previous events line because the new line is in the wrong place.

Close #138