### PR TITLE
Add sandbox command to contain deploy, invoke, read

### DIFF
--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,0 +1,50 @@
+mod deploy;
+mod invoke;
+mod read;
+
+use std::fmt::Debug;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+pub struct Cmd {
+    /// File to persist ledger state
+    #[clap(long, parse(from_os_str), default_value(".soroban/ledger.json"))]
+    ledger_file: std::path::PathBuf,
+    #[clap(subcommand)]
+    cmd: SubCmd,
+}
+
+#[derive(Subcommand, Debug)]
+enum SubCmd {
+    /// Invoke a contract function in a WASM file
+    Invoke(invoke::Cmd),
+    /// Print the current value of a contract-data ledger entry
+    Read(read::Cmd),
+    /// Deploy a WASM file as a contract
+    Deploy(deploy::Cmd),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Invoke(#[from] invoke::Error),
+    #[error(transparent)]
+    Read(#[from] read::Error),
+    #[error(transparent)]
+    Deploy(#[from] deploy::Error),
+}
+
+impl Cmd {
+    pub fn run(&self, matches: &mut clap::ArgMatches) -> Result<(), Error> {
+        match &self.cmd {
+            SubCmd::Invoke(invoke) => {
+                let (_, sub_arg_matches) = matches.remove_subcommand().unwrap();
+                invoke.run(&self.ledger_file, &sub_arg_matches)?;
+            }
+            SubCmd::Read(read) => read.run(&self.ledger_file)?,
+            SubCmd::Deploy(deploy) => deploy.run(&self.ledger_file)?,
+        };
+        Ok(())
+    }
+}

--- a/src/sandbox/read.rs
+++ b/src/sandbox/read.rs
@@ -31,9 +31,6 @@ pub struct Cmd {
     /// Type of output to generate
     #[clap(long, arg_enum, default_value("string"))]
     output: Output,
-    /// File to persist ledger state
-    #[clap(long, parse(from_os_str), default_value(".soroban/ledger.json"))]
-    ledger_file: std::path::PathBuf,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ArgEnum)]
@@ -80,7 +77,7 @@ pub enum Error {
 }
 
 impl Cmd {
-    pub fn run(&self) -> Result<(), Error> {
+    pub fn run(&self, ledger_file: &std::path::PathBuf) -> Result<(), Error> {
         let contract_id: [u8; 32] =
             utils::contract_id_from_str(&self.contract_id).map_err(|e| {
                 Error::CannotParseContractId {
@@ -103,8 +100,8 @@ impl Cmd {
         };
 
         // Initialize storage
-        let state = snapshot::read(&self.ledger_file).map_err(|e| Error::CannotReadLedgerFile {
-            filepath: self.ledger_file.clone(),
+        let state = snapshot::read(ledger_file).map_err(|e| Error::CannotReadLedgerFile {
+            filepath: ledger_file.clone(),
             error: e,
         })?;
 


### PR DESCRIPTION
### What
Add sandbox command to contain the sandbox versions of deploy, invoke, read.

### Why
I took a quick look at how a remote deploy command would be added (#41) and it soon became overwhelming thinking about how to have such a command coexist with the code in the sandbox deploy command. 

At some point someone had expressed interest in grouping sandbox command under a sandbox super command so as to clearly separate them from commands that invoke remote services. I think it might have been @paulbellamy who had dropped this idea in a doc a long time ago.

We never did it, but I think it will make it easier to implement the following tasks if we have the sandbox variations under `sandbox` and put the remote variations of the commands under another subcommand such as `remote`:
- #41
- #42
- #142

This change makes no functional changes and is purely moving code into a directory (so it is in a Rust module under sandbox), and inserting the sandbox command in between them.

Close https://github.com/stellar/soroban-cli/issues/165