### PR TITLE
Scaffold remote command to contain deploy, invoke, read

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod gen;
 mod inspect;
 mod jsonrpc;
 mod network;
+mod remote;
 mod sandbox;
 mod serve;
 mod snapshot;
@@ -29,6 +30,8 @@ struct Root {
 enum Cmd {
     /// Run commands against a local sandbox
     Sandbox(sandbox::Cmd),
+    /// Run commands against a remote environment / network
+    Remote(remote::Cmd),
 
     /// Inspect a WASM file listing contract functions, meta, etc
     Inspect(inspect::Cmd),
@@ -52,6 +55,8 @@ enum CmdError {
     #[error(transparent)]
     Sandbox(#[from] sandbox::Error),
     #[error(transparent)]
+    Remote(#[from] remote::Error),
+    #[error(transparent)]
     Serve(#[from] serve::Error),
     #[error(transparent)]
     Gen(#[from] gen::Error),
@@ -63,6 +68,10 @@ async fn run(cmd: Cmd, matches: &mut clap::ArgMatches) -> Result<(), CmdError> {
         Cmd::Sandbox(sandbox) => {
             let (_, mut sub_arg_matches) = matches.remove_subcommand().unwrap();
             sandbox.run(&mut sub_arg_matches)?;
+        }
+        Cmd::Remote(remote) => {
+            let (_, mut sub_arg_matches) = matches.remove_subcommand().unwrap();
+            remote.run(&mut sub_arg_matches)?;
         }
         Cmd::Serve(serve) => serve.run().await?,
         Cmd::Gen(gen) => gen.run()?,

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,0 +1,61 @@
+mod deploy;
+mod invoke;
+
+use std::fmt::Debug;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+pub struct Cmd {
+    /// Horizon URL
+    #[clap(long, conflicts_with("horizon_url"))]
+    horizon_url: Option<String>,
+    /// RPC URL
+    #[clap(long, conflicts_with("horizon_url"))]
+    rpc_url: Option<String>,
+    #[clap(subcommand)]
+    cmd: SubCmd,
+}
+
+pub enum Remote<'a> {
+    HorizonUrl(&'a str),
+    RpcUrl(&'a str),
+}
+
+#[derive(Subcommand, Debug)]
+enum SubCmd {
+    /// Deploy a WASM file as a contract
+    Deploy(deploy::Cmd),
+    /// Invoke a contract
+    Invoke(invoke::Cmd),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("no --horizon-url or --rpc-url provided")]
+    NoUrl,
+    #[error(transparent)]
+    Deploy(#[from] deploy::Error),
+    #[error(transparent)]
+    Invoke(#[from] invoke::Error),
+}
+
+impl Cmd {
+    pub fn run(&self, matches: &mut clap::ArgMatches) -> Result<(), Error> {
+        let remote = if let Some(horizon_url) = &self.horizon_url {
+            Remote::HorizonUrl(horizon_url)
+        } else if let Some(rpc_url) = &self.rpc_url {
+            Remote::RpcUrl(rpc_url)
+        } else {
+            return Err(Error::NoUrl);
+        };
+        match &self.cmd {
+            SubCmd::Deploy(deploy) => deploy.run(&remote)?,
+            SubCmd::Invoke(invoke) => {
+                let (_, sub_arg_matches) = matches.remove_subcommand().unwrap();
+                invoke.run(&remote, &sub_arg_matches)?;
+            }
+        };
+        Ok(())
+    }
+}

--- a/src/remote/deploy.rs
+++ b/src/remote/deploy.rs
@@ -1,0 +1,37 @@
+use std::{fmt::Debug, fs, io};
+
+use clap::Parser;
+use soroban_env_host::xdr::Error as XdrError;
+
+use super::Remote;
+
+#[derive(Parser, Debug)]
+pub struct Cmd {
+    /// WASM file to deploy
+    #[clap(long, parse(from_os_str))]
+    wasm: std::path::PathBuf,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("xdr processing error: {0}")]
+    Xdr(#[from] XdrError),
+    #[error("reading file {filepath}: {error}")]
+    CannotReadContractFile {
+        filepath: std::path::PathBuf,
+        error: io::Error,
+    },
+}
+
+impl Cmd {
+    pub fn run(&self, _remote: &Remote) -> Result<(), Error> {
+        let _contract = fs::read(&self.wasm).map_err(|e| Error::CannotReadContractFile {
+            filepath: self.wasm.clone(),
+            error: e,
+        })?;
+
+        // TODO: Call out to RPC or horizon to deploy.
+
+        Ok(())
+    }
+}

--- a/src/remote/invoke.rs
+++ b/src/remote/invoke.rs
@@ -1,0 +1,63 @@
+use std::fmt::Debug;
+
+use clap::Parser;
+use hex::FromHexError;
+
+use crate::utils;
+
+use super::Remote;
+
+#[derive(Parser, Debug)]
+pub struct Cmd {
+    /// Contract ID to invoke
+    #[clap(long = "id")]
+    contract_id: String,
+    /// Function name to execute
+    #[clap(long = "fn")]
+    function: String,
+    /// Argument to pass to the function
+    #[clap(long = "arg", value_name = "arg", multiple = true)]
+    args: Vec<String>,
+    /// Argument to pass to the function (base64-encoded xdr)
+    #[clap(long = "arg-xdr", value_name = "arg-xdr", multiple = true)]
+    args_xdr: Vec<String>,
+    /// Output the cost execution to stderr
+    #[clap(long = "cost")]
+    cost: bool,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("cannot parse contract ID {contract_id}: {error}")]
+    CannotParseContractId {
+        contract_id: String,
+        error: FromHexError,
+    },
+}
+
+// TODO: Copy / share logic from sandbox::invoke for parsing args.
+
+impl Cmd {
+    pub fn run(&self, _remote: &Remote, _matches: &clap::ArgMatches) -> Result<(), Error> {
+        let _contract_id: [u8; 32] =
+            utils::contract_id_from_str(&self.contract_id).map_err(|e| {
+                Error::CannotParseContractId {
+                    contract_id: self.contract_id.clone(),
+                    error: e,
+                }
+            })?;
+
+        // TODO: Get contract WASM file from remote for extracting inputs from
+        // contract spec.
+
+        // TODO: Parse args based on contract spec, similar to sandbox::invoke.
+
+        // TODO: Invoke contract on remote RPC/Horizon.
+
+        // TODO: Print result.
+
+        // TODO: Print events.
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
### What
Scaffold remote command to contain deploy, invoke, read.

### Why
A follow on from https://github.com/stellar/soroban-cli/pull/144.

If sandbox and remote variants of these commands are to live somewhere, then we need some place for remote commands to go.

This PR won't add any logic for remote commands, as that will be handled in:
- #41
- #42
- #142
- and others

### Merging
This change is intended for merging to `main` after #144.