### PR TITLE
Add js sdk client headers through cors

### DIFF
--- a/src/serve.rs
+++ b/src/serve.rs
@@ -96,6 +96,8 @@ impl Cmd {
                 "Referer",
                 "Sec-Fetch-Mode",
                 "User-Agent",
+                "X-Client-Name",
+                "X-Client-Version",
             ])
             .allow_methods(vec!["GET", "POST"]);
         let routes = jsonrpc_route.with(cors);


### PR DESCRIPTION
### What

Have CLI serve accept the client headers from js-soroban-sdk.

### Why

So that js-soroban-sdk can talk to the local sandbox via cli serve.

### Known limitations

[TODO or N/A]
