### PR TITLE
Support getting all data for contract with read command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "buf_redux"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +205,28 @@ checksum = "2ccfd8c0ee4cce11e45b3fd6f9d5e69e0cc62912aa6a0cb1bf4617b0eba5a12f"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -487,7 +521,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.2",
 ]
 
 [[package]]
@@ -528,7 +562,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -604,9 +638,21 @@ dependencies = [
 
 [[package]]
 name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -1012,6 +1058,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,7 +1128,7 @@ version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
- "itoa",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -1088,7 +1140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -1198,6 +1250,7 @@ dependencies = [
  "base64",
  "clap",
  "clap_complete",
+ "csv",
  "hex",
  "num-bigint",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-strkey"
 version = "0.0.2"
-source = "git+https://github.com/stellar/rs-stellar-strkey?rev=cbb9651f#cbb9651f4a74adae0feac40374aa653cde650f1b"
+source = "git+https://github.com/stellar/rs-stellar-strkey?rev=dc234c4#dc234c4d0d57ffbe60e31e8c34e109ad409fd3bb"
 dependencies = [
  "base32",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-strkey"
 version = "0.0.2"
-source = "git+https://github.com/stellar/rs-stellar-strkey?rev=dc234c4#dc234c4d0d57ffbe60e31e8c34e109ad409fd3bb"
+source = "git+https://github.com/stellar/rs-stellar-strkey?rev=cbb9651f#cbb9651f4a74adae0feac40374aa653cde650f1b"
 dependencies = [
  "base32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ csv = "1.1.6"
 
 [patch.crates-io]
 soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "81536e10" }
-stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "3c21b987" }
+stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "dc234c4" }
 soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "e110dff7" }
 soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "e110dff7" }
 soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "e110dff7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ csv = "1.1.6"
 
 [patch.crates-io]
 soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "81536e10" }
-stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "dc234c4" }
+stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "3c21b987" }
 soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "e110dff7" }
 soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "e110dff7" }
 soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "e110dff7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ clap_complete = "3.2.3"
 syn = { version = "1.0.99", features = ["parsing"] }
 wasmparser = "0.90.0"
 sha2 = "0.10.2"
+csv = "1.1.6"
 
 [patch.crates-io]
 soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "81536e10" }

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -13,7 +13,6 @@ use soroban_env_host::{
     Host, HostError,
 };
 use soroban_spec::read::FromWasmError;
-use stellar_strkey::StrkeyPublicKeyEd25519;
 
 use crate::{
     snapshot,
@@ -26,12 +25,6 @@ pub struct Cmd {
     /// Contract ID to invoke
     #[clap(long = "id")]
     contract_id: String,
-    /// Account ID to invoke as
-    #[clap(
-        long = "account",
-        default_value = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
-    )]
-    account_id: StrkeyPublicKeyEd25519,
     /// WASM file to deploy to the contract ID and invoke
     #[clap(long, parse(from_os_str))]
     wasm: Option<std::path::PathBuf>,
@@ -244,9 +237,7 @@ impl Cmd {
         let contents = utils::get_contract_wasm_from_storage(&mut storage, contract_id)?;
         let h = Host::with_storage_and_budget(storage, Budget::default());
 
-        h.set_source_account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
-            self.account_id.0,
-        ))));
+        h.set_source_account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0; 32]))));
 
         let mut ledger_info = state.0.clone();
         ledger_info.sequence_number += 1;

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -13,6 +13,7 @@ use soroban_env_host::{
     Host, HostError,
 };
 use soroban_spec::read::FromWasmError;
+use stellar_strkey::StrkeyPublicKeyEd25519;
 
 use crate::{
     snapshot,
@@ -25,6 +26,12 @@ pub struct Cmd {
     /// Contract ID to invoke
     #[clap(long = "id")]
     contract_id: String,
+    /// Account ID to invoke as
+    #[clap(
+        long = "account",
+        default_value = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+    )]
+    account_id: StrkeyPublicKeyEd25519,
     /// WASM file to deploy to the contract ID and invoke
     #[clap(long, parse(from_os_str))]
     wasm: Option<std::path::PathBuf>,
@@ -237,7 +244,9 @@ impl Cmd {
         let contents = utils::get_contract_wasm_from_storage(&mut storage, contract_id)?;
         let h = Host::with_storage_and_budget(storage, Budget::default());
 
-        h.set_source_account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0; 32]))));
+        h.set_source_account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+            self.account_id.0,
+        ))));
 
         let mut ledger_info = state.0.clone();
         ledger_info.sequence_number += 1;

--- a/src/read.rs
+++ b/src/read.rs
@@ -84,6 +84,7 @@ pub enum Error {
 }
 
 impl Cmd {
+    #[allow(clippy::too_many_lines)]
     pub fn run(&self) -> Result<(), Error> {
         let contract_id: [u8; 32] =
             utils::contract_id_from_str(&self.contract_id).map_err(|e| {

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,12 +1,14 @@
-use std::{fmt::Debug, rc::Rc};
+use std::{
+    fmt::Debug,
+    io::{self, stdout},
+};
 
 use clap::{ArgEnum, Parser};
 use hex::FromHexError;
 use soroban_env_host::{
-    storage::Storage,
     xdr::{
-        self, Error as XdrError, LedgerEntryData, LedgerKey, LedgerKeyContractData, ReadXdr,
-        ScSpecTypeDef, ScVal, WriteXdr,
+        self, ContractDataEntry, Error as XdrError, LedgerEntryData, LedgerKey,
+        LedgerKeyContractData, ReadXdr, ScSpecTypeDef, ScVal, WriteXdr,
     },
     HostError,
 };
@@ -52,8 +54,6 @@ pub enum Error {
     CannotParseKey { key: String, error: StrValError },
     #[error("parsing XDR key {key}: {error}")]
     CannotParseXdrKey { key: String, error: XdrError },
-    #[error("missing key argument")]
-    MissingKey,
     #[error("reading file {filepath}: {error}")]
     CannotReadLedgerFile {
         filepath: std::path::PathBuf,
@@ -71,6 +71,10 @@ pub enum Error {
         result: ScVal,
         error: serde_json::Error,
     },
+    #[error("cannot print as csv: {error}")]
+    CannotPrintAsCsv { error: csv::Error },
+    #[error("cannot print: {error}")]
+    CannotPrintFlush { error: io::Error },
     #[error("xdr processing error: {0}")]
     Xdr(#[from] XdrError),
     #[error(transparent)]
@@ -89,59 +93,101 @@ impl Cmd {
                 }
             })?;
         let key = if let Some(key) = &self.key {
-            strval::from_string(key, &ScSpecTypeDef::Symbol).map_err(|e| Error::CannotParseKey {
-                key: key.clone(),
-                error: e,
-            })?
+            Some(
+                strval::from_string(key, &ScSpecTypeDef::Symbol).map_err(|e| {
+                    Error::CannotParseKey {
+                        key: key.clone(),
+                        error: e,
+                    }
+                })?,
+            )
         } else if let Some(key) = &self.key_xdr {
-            ScVal::from_xdr_base64(key.to_string()).map_err(|e| Error::CannotParseXdrKey {
-                key: key.clone(),
-                error: e,
-            })?
+            Some(
+                ScVal::from_xdr_base64(key.to_string()).map_err(|e| Error::CannotParseXdrKey {
+                    key: key.clone(),
+                    error: e,
+                })?,
+            )
         } else {
-            return Err(Error::MissingKey);
+            None
         };
 
-        // Initialize storage
         let state = snapshot::read(&self.ledger_file).map_err(|e| Error::CannotReadLedgerFile {
             filepath: self.ledger_file.clone(),
             error: e,
         })?;
+        let ledger_entries = state.1;
 
-        let snap = Rc::new(snapshot::Snap {
-            ledger_entries: state.1,
-        });
-        let mut storage = Storage::with_recording_footprint(snap);
-        let ledger_entry = storage.get(&LedgerKey::ContractData(LedgerKeyContractData {
-            contract_id: xdr::Hash(contract_id),
-            key,
-        }))?;
-
-        let value = if let LedgerEntryData::ContractData(entry) = ledger_entry.data {
-            entry.val
+        let contract_id = xdr::Hash(contract_id);
+        let entries: Vec<ContractDataEntry> = if let Some(key) = key {
+            ledger_entries
+                .get(&LedgerKey::ContractData(LedgerKeyContractData {
+                    contract_id,
+                    key,
+                }))
+                .iter()
+                .copied()
+                .cloned()
+                .filter_map(|val| {
+                    if let LedgerEntryData::ContractData(d) = val.data {
+                        Some(d)
+                    } else {
+                        None
+                    }
+                })
+                .collect()
         } else {
-            unreachable!();
+            ledger_entries
+                .iter()
+                .filter_map(|(k, v)| {
+                    if let LedgerKey::ContractData(kd) = k {
+                        if kd.contract_id == contract_id
+                            && kd.key != ScVal::Static(xdr::ScStatic::LedgerKeyContractCode)
+                        {
+                            if let LedgerEntryData::ContractData(vd) = &v.data {
+                                return Some(vd.clone());
+                            }
+                        }
+                    }
+                    None
+                })
+                .collect()
         };
 
-        match self.output {
-            Output::String => {
-                let res_str = strval::to_string(&value).map_err(|e| Error::CannotPrintResult {
-                    result: value,
-                    error: e,
-                })?;
-                println!("{}", res_str);
-            }
-            Output::Json => {
-                let res_str = serde_json::to_string_pretty(&value).map_err(|e| {
-                    Error::CannotPrintJsonResult {
-                        result: value,
+        let mut out = csv::Writer::from_writer(stdout());
+        for data in entries {
+            let output = match self.output {
+                Output::String => [
+                    strval::to_string(&data.key).map_err(|e| Error::CannotPrintResult {
+                        result: data.key.clone(),
                         error: e,
-                    }
-                })?;
-                println!("{}", res_str);
-            }
-            Output::Xdr => println!("{}", value.to_xdr_base64()?),
+                    })?,
+                    strval::to_string(&data.val).map_err(|e| Error::CannotPrintResult {
+                        result: data.val.clone(),
+                        error: e,
+                    })?,
+                ],
+                Output::Json => [
+                    serde_json::to_string_pretty(&data.key).map_err(|e| {
+                        Error::CannotPrintJsonResult {
+                            result: data.key.clone(),
+                            error: e,
+                        }
+                    })?,
+                    serde_json::to_string_pretty(&data.val).map_err(|e| {
+                        Error::CannotPrintJsonResult {
+                            result: data.val.clone(),
+                            error: e,
+                        }
+                    })?,
+                ],
+                Output::Xdr => [data.key.to_xdr_base64()?, data.val.to_xdr_base64()?],
+            };
+            out.write_record(output)
+                .map_err(|e| Error::CannotPrintAsCsv { error: e })?;
         }
+        out.flush()
+            .map_err(|e| Error::CannotPrintFlush { error: e })?;
 
         Ok(())
     }


### PR DESCRIPTION
### What
Change the read subcommand so that it can be given just a contract ID and it will output all the data stored.

### Why
While I've been testing invoker functionality it's easier to just look at a contracts data as a whole rather than individual records.