### PR TITLE
Add option for choosing which account invoke happens as

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-strkey"
 version = "0.0.2"
-source = "git+https://github.com/stellar/rs-stellar-strkey?rev=dc234c4#dc234c4d0d57ffbe60e31e8c34e109ad409fd3bb"
+source = "git+https://github.com/stellar/rs-stellar-strkey?rev=cbb9651f#cbb9651f4a74adae0feac40374aa653cde650f1b"
 dependencies = [
  "base32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ csv = "1.1.6"
 
 [patch.crates-io]
 soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "81536e10" }
-stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "dc234c4" }
+stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "3c21b987" }
 soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "e110dff7" }
 soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "e110dff7" }
 soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "e110dff7" }

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -13,6 +13,7 @@ use soroban_env_host::{
     Host, HostError,
 };
 use soroban_spec::read::FromWasmError;
+use stellar_strkey::StrkeyPublicKeyEd25519;
 
 use crate::{
     snapshot,
@@ -25,6 +26,12 @@ pub struct Cmd {
     /// Contract ID to invoke
     #[clap(long = "id")]
     contract_id: String,
+    /// Account ID to invoke as
+    #[clap(
+        long = "account",
+        default_value = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+    )]
+    account_id: StrkeyPublicKeyEd25519,
     /// WASM file to deploy to the contract ID and invoke
     #[clap(long, parse(from_os_str))]
     wasm: Option<std::path::PathBuf>,
@@ -237,7 +244,9 @@ impl Cmd {
         let contents = utils::get_contract_wasm_from_storage(&mut storage, contract_id)?;
         let h = Host::with_storage_and_budget(storage, Budget::default());
 
-        h.set_source_account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0; 32]))));
+        h.set_source_account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+            self.account_id.0,
+        ))));
 
         let mut ledger_info = state.0.clone();
         ledger_info.sequence_number += 1;


### PR DESCRIPTION
### What
Add option for choosing which account invoke happens as.

### Why
So it's possible to choose which account is sending the invocation.

Close https://github.com/stellar/soroban-cli/issues/153