### PR TITLE
Add source account support to serve simulate/sendTransaction

### DIFF
--- a/src/serve.rs
+++ b/src/serve.rs
@@ -243,7 +243,7 @@ fn parse_transaction(
         return Err(Error::Xdr(XdrError::Invalid));
     }
     let op = ops.first().ok_or(Error::Xdr(XdrError::Invalid))?;
-    let source_account = parse_op_source_account(&transaction, &op);
+    let source_account = parse_op_source_account(&transaction, op);
     let body = if let OperationBody::InvokeHostFunction(b) = &op.body {
         b
     } else {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -535,6 +535,7 @@ async fn send_transaction(
 }
 
 fn tx_source_account(transaction: &TransactionEnvelope) -> AccountId {
+    // TODO: Read it from the tx op as well and use that as precedence.
     match transaction {
         TransactionEnvelope::TxV0(envelope) => AccountId(PublicKey::PublicKeyTypeEd25519(
             envelope.tx.source_account_ed25519.clone(),


### PR DESCRIPTION
### What
When a transaction is received via sendTransaction or simulateTransaction, read out the source account and use it as the source account of the host when invoking the transaction.

### Why
To add support for using the source account as msg.sender style auth.

Close https://github.com/stellar/soroban-cli/issues/158