### PR TITLE
Log errors to stderr in serve

### DIFF
--- a/src/serve.rs
+++ b/src/serve.rs
@@ -511,9 +511,8 @@ async fn send_transaction(
                                 "results": vec![result],
                             })
                         }
-                        Err(_err) => {
-                            // TODO: Actually render the real error to the user
-                            // Add it to our status tracker
+                        Err(err) => {
+                            eprintln!("error: {:?}", err);
                             json!({
                                 "id": id,
                                 "status": "error",


### PR DESCRIPTION
### What
Log errors to stderr in serve

### Why
It's impossible to know what caused a transaction to fail without seeing the contents of the error. While there might be nicer things for us to do, simply logging the error to stderr will go a long way for a developer running serve locally in understanding what happened.