### PR TITLE
Update deploy subcommand to use `create_contract_from_source()`

### DIFF
--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -203,6 +203,9 @@ impl Cmd {
             self.network_passphrase.as_ref().unwrap(),
             &key,
         )?;
+
+        println!("Contract ID: {}", hex::encode(contract_id.0));
+
         client
             .request("sendTransaction", rpc_params![tx.to_xdr_base64()?])
             .await?;
@@ -216,7 +219,6 @@ impl Cmd {
             match response.status.as_str() {
                 "success" => {
                     println!("{}", response.status.as_str());
-                    println!("Contract ID: {}", hex::encode(contract_id.0));
                     return Ok(());
                 }
                 "error" => {


### PR DESCRIPTION
### What

Update deploy subcommand so that when it's used against an RPC server uses `create_contract_from_source()` instead of `create_contract_from_ed25519()`

Also, print the contract ID once created.

I used this CPP test as a reference: https://github.com/stellar/stellar-core/blob/2dccaae1ec9db8e82580bc5e7b84d404d1836f3c/src/transactions/test/InvokeHostFunctionTests.cpp#L135

### Why

#152 

### Known limitations

I haven't really been able to test this end-to-end against an RPC server because `soroban-cli serve` still only seems to support `HostFunction::InvokeContract`


