### PR TITLE
deploy: Allow setting private key from env variable

### DIFF
--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -61,10 +61,8 @@ pub struct Cmd {
         requires = "network-passphrase"
     )]
     rpc_server_url: Option<String>,
-    // TODO: we should probably use an env variable for security reasons
-    //       (otherwise it will get recorded in the shell history etc ...)
     /// Private key to sign the transaction sent to the rpc server
-    #[clap(long = "private-strkey")]
+    #[clap(long = "private-strkey", env)]
     private_strkey: Option<String>,
     /// Network passphrase to sign the transaction sent to the rpc server
     #[clap(long = "network-passphrase")]


### PR DESCRIPTION
### What

Allow setting private key from environment variable `PRIVATE_STRKEY`

```
        --private-strkey <PRIVATE_STRKEY>
            Private key to sign the transaction sent to the rpc server [env: PRIVATE_STRKEY=]
```

### Why

Security 

### Known limitations

N/A
