### PR TITLE
Improve serve's txn processing error messages

### DIFF
--- a/src/serve.rs
+++ b/src/serve.rs
@@ -50,6 +50,8 @@ pub enum Error {
     Snapshot(#[from] snapshot::Error),
     #[error("serde")]
     Serde(#[from] serde_json::Error),
+    #[error("unsupported transaction: {message}")]
+    UnsupportedTransaction { message: String },
     #[error("hex")]
     FromHex(#[from] FromHexError),
     #[error("unknownmethod")]
@@ -240,42 +242,58 @@ fn parse_transaction(
         }
     };
     if ops.len() != 1 {
-        return Err(Error::Xdr(XdrError::Invalid));
+        return Err(Error::UnsupportedTransaction {
+            message: "Must only have one operation".to_string()
+        });
     }
     let op = ops.first().ok_or(Error::Xdr(XdrError::Invalid))?;
     let source_account = parse_op_source_account(&transaction, op);
     let body = if let OperationBody::InvokeHostFunction(b) = &op.body {
         b
     } else {
-        return Err(Error::Xdr(XdrError::Invalid));
+        return Err(Error::UnsupportedTransaction {
+            message: "Operation must be invokeHostFunction".to_string()
+        });
     };
 
     // TODO: Support creating contracts and token wrappers here as well.
     if body.function != HostFunction::InvokeContract {
-        return Err(Error::Xdr(XdrError::Invalid));
+        return Err(Error::UnsupportedTransaction {
+            message: "Function must be invokeContract".to_string()
+        });
     };
 
     if body.parameters.len() < 2 {
-        return Err(Error::Xdr(XdrError::Invalid));
+        return Err(Error::UnsupportedTransaction {
+            message: "Function must have at least 2 parameters".to_string()
+        });
     };
 
     let contract_xdr = body
         .parameters
         .get(0)
-        .ok_or(Error::Xdr(XdrError::Invalid))?;
+        .ok_or(Error::UnsupportedTransaction {
+            message: "First parameter must be the contract id".to_string()
+        })?;
     let method_xdr = body
         .parameters
         .get(1)
-        .ok_or(Error::Xdr(XdrError::Invalid))?;
+        .ok_or(Error::UnsupportedTransaction {
+            message: "Second parameter must be the contract method".to_string()
+        })?;
     let (_, params) = body.parameters.split_at(2);
 
     let contract_id: [u8; 32] = if let ScVal::Object(Some(ScObject::Bytes(bytes))) = contract_xdr {
         bytes
             .as_slice()
             .try_into()
-            .map_err(|_| Error::Xdr(XdrError::Invalid))?
+            .map_err(|_| Error::UnsupportedTransaction {
+                message: "Could not parse contract id".to_string()
+            })?
     } else {
-        return Err(Error::Xdr(XdrError::Invalid));
+        return Err(Error::UnsupportedTransaction {
+            message: "Could not parse contract id".to_string()
+        });
     };
 
     // TODO: Figure out and enforce the expected type here. For now, handle both a symbol and a
@@ -283,13 +301,19 @@ fn parse_transaction(
     let method: String = if let ScVal::Object(Some(ScObject::Bytes(bytes))) = method_xdr {
         bytes
             .try_into()
-            .map_err(|_| Error::Xdr(XdrError::Invalid))?
+            .map_err(|_| Error::UnsupportedTransaction {
+                message: "Could not parse contract method".to_string()
+            })?
     } else if let ScVal::Symbol(bytes) = method_xdr {
         bytes
             .try_into()
-            .map_err(|_| Error::Xdr(XdrError::Invalid))?
+            .map_err(|_| Error::UnsupportedTransaction {
+                message: "Could not parse contract method".to_string()
+            })?
     } else {
-        return Err(Error::Xdr(XdrError::Invalid));
+        return Err(Error::UnsupportedTransaction {
+            message: "Could not parse contract method".to_string()
+        });
     };
 
     let mut complete_args = vec![


### PR DESCRIPTION
### What

Small improvement to cli serve's errors when processing error messages.

### Why

So they're not all `InvalidXdr`, which is kind of useless.