### PR TITLE
Rename soroban-cli to soroban

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ readme = "README.md"
 version = "0.0.4"
 edition = "2021"
 rust-version = "1.64"
+autobins = false
+
+[[bin]]
+name = "soroban"
+path = "src/main.rs"
 
 [dependencies]
 soroban-env-host = { version = "0.0.5", features = ["vm", "serde", "hostfn_log_fmt_values"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod xdr;
 
 #[derive(Parser, Debug)]
 #[clap(
+    name = "soroban",
     version,
     about = "https://soroban.stellar.org",
     disable_help_subcommand = true,


### PR DESCRIPTION
### What
Rename the binary that gets installed when installing `soroban-cli`, from `soroban-cli` to `soroban`.

### Why
In a conversation with @tomerweller last week we were discussing the long name of this tool, and he suggested simply `soroban`. I think it works.

There may be other short names we may want to consider, but this is as short as we can go without losing any meaning.