### PR TITLE
Allow user to specify custom salt when deploying to remote rpc server

### DIFF
--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -67,7 +67,6 @@ pub struct Cmd {
         conflicts_with_all = &["contract-id", "ledger-file"],
     )]
     salt: Option<String>,
-
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -150,9 +149,8 @@ impl Cmd {
     async fn run_against_rpc_server(&self, contract: Vec<u8>) -> Result<(), Error> {
         let salt: [u8; 32] = match &self.salt {
             // Hack: re-use contract_id_from_str to parse the 32-byte salt hex.
-            Some(h) => utils::contract_id_from_str(&h).map_err(|_| Error::CannotParseSalt {
-                salt: h.clone(),
-            })?,
+            Some(h) => utils::contract_id_from_str(h)
+                .map_err(|_| Error::CannotParseSalt { salt: h.clone() })?,
             None => rand::thread_rng().gen::<[u8; 32]>(),
         };
 


### PR DESCRIPTION
### What

Allow user to specify custom salt when deploying to remote rpc server, via:

```sh
$ soroban deploy \
  --wasm target/wasm32-unknown-unknown/release/soroban_hello_world_contract.wasm \
  --rpc-server-url http://localhost:8000/soroban/rpc \
  --secret-key "$SECRET_KEY" \
  --network-passphrase "$NETWORK_PASSPHRASE" \
  --salt 0
Contract ID: 1f3eb7b8dc051d6aa46db5454588a142c671a0cdcdb36a2f754d9675a64bf613
```

### Why

It means that the contract will have a deterministic ID, so it will fail if it is already deployed.

### Known limitations

[TODO or N/A]
