### PR TITLE
Don't print rpc status to stdout

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -120,7 +120,7 @@ impl Client {
             let response = self.get_transaction_status(&id).await?;
             match response.status.as_str() {
                 "success" => {
-                    println!("{}", response.status);
+                    eprintln!("{}", response.status);
                     return Ok(SendTransactionResponse {
                         id: response.id,
                         status: response.status,


### PR DESCRIPTION
### What

Print rpc status to stderr instead of stdout

### Why

Because if you print it to stdout it breaks:
```sh
CONTRACT_ID=$(soroban deploy ...)
```

### Known limitations

[TODO or N/A]
