### PR TITLE
Fix binary name in instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ All values passed to `--arg` are the JSON representation of SCVals.
 ## Example
 
 ```
-soroban-cli invoke --id <HEX_CONTRACTID> --wasm <WASMFILE> --fn <FUNCNAME> --arg 32 --arg 4
+soroban invoke --id <HEX_CONTRACTID> --wasm <WASMFILE> --fn <FUNCNAME> --arg 32 --arg 4
 ```


### PR DESCRIPTION
### What

Change example binary name

### Why

In the Cargo.toml the binary is given the shorter name so when installed is the one added to your path.

### Known limitations

N/A