### PR TITLE
Fix a bug in the return format of sendTransaction

### DIFF
--- a/src/serve.rs
+++ b/src/serve.rs
@@ -531,11 +531,13 @@ async fn send_transaction(
                     id.clone(),
                     match result {
                         Ok(result) => {
-                            json!({
-                                "id": id,
-                                "status": "success",
-                                "results": vec![result],
-                            })
+                            if let Value::Object(mut o) = result {
+                                o.insert("id".to_string(), Value::String(id.to_string()));
+                                o.insert("status".to_string(), Value::String("success".to_string()));
+                                Value::Object(o)
+                            } else {
+                                panic!("Expected object");
+                            }
                         }
                         Err(err) => {
                             eprintln!("error: {:?}", err);


### PR DESCRIPTION
### What

previous format had:
```json
{
  "id": "<hash>",
  "status": "success",
  "results": [
    {
      "results": [ { "xdr": "<scval>" } ]
    }
  ]
}
```

### Why

It should be:
```json
{
  "id": "<hash>",
  "status": "success",
  "results": [ { "xdr": "<scval>" } ]
}
```

### Known limitations

[TODO or N/A]
