### PR TITLE
Add git sha to version information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,12 @@ version = "0.0.4"
 edition = "2021"
 rust-version = "1.64"
 autobins = false
+build = "build.rs"
+
+[build-dependencies]
+serde = "1.0.82"
+serde_derive = "1.0.82"
+serde_json = "1.0.82"
 
 [[bin]]
 name = "soroban"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,43 @@
+use serde_derive::{Deserialize, Serialize};
+use std::{fs::read_to_string, process::Command, str};
+
+fn main() {
+    println!("cargo:rerun-if-changed=.");
+
+    let mut git_sha: Option<String> = None;
+
+    if let Ok(vcs_info) = read_to_string(".cargo_vcs_info.json") {
+        let vcs_info: Result<CargoVcsInfo, _> = serde_json::from_str(&vcs_info);
+        if let Ok(vcs_info) = vcs_info {
+            git_sha = Some(vcs_info.git.sha1);
+        }
+    }
+
+    if git_sha.is_none() {
+        if let Ok(git_describe) = Command::new("git")
+            .arg("describe")
+            .arg("--always")
+            .arg("--exclude='*'")
+            .arg("--long")
+            .arg("--dirty")
+            .output()
+            .map(|o| o.stdout)
+        {
+            git_sha = str::from_utf8(&git_describe).ok().map(str::to_string);
+        }
+    }
+
+    if let Some(git_sha) = git_sha {
+        println!("cargo:rustc-env=GIT_SHA={}", git_sha);
+    }
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct CargoVcsInfo {
+    git: CargoVcsInfoGit,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct CargoVcsInfoGit {
+    sha1: String,
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -2,13 +2,19 @@ use clap::Parser;
 use soroban_env_host::meta;
 use std::fmt::Debug;
 
+const GIT_SHA: Option<&str> = option_env!("GIT_SHA");
+
 #[derive(Parser, Debug)]
 pub struct Cmd;
 
 impl Cmd {
     #[allow(clippy::unused_self)]
     pub fn run(&self) {
-        println!("soroban-cli {}", env!("CARGO_PKG_VERSION"),);
-        println!("soroban-env interface {}", meta::INTERFACE_VERSION);
+        println!(
+            "soroban-cli {} ({})",
+            env!("CARGO_PKG_VERSION"),
+            GIT_SHA.unwrap_or_default(),
+        );
+        println!("soroban-env-interface-version: {}", meta::INTERFACE_VERSION);
     }
 }


### PR DESCRIPTION
### What
Add git sha to version information.

### Why
So that we know if something is a development version or not, and which version exactly.