### PR TITLE
Add contractCode to token init footprint

### DIFF
--- a/src/token/create.rs
+++ b/src/token/create.rs
@@ -377,11 +377,11 @@ fn build_init_op(contract_id: &Hash, parameters: ScVec) -> Result<Operation, Err
                 read_write: vec![
                     ContractData(LedgerKeyContractData {
                         contract_id: contract_id.clone(),
-                        key: ScVal::Symbol("Admin".try_into().unwrap()),
+                        key: ScVal::Object(Some(ScObject::Vec(vec![ScVal::Symbol("Admin".try_into().unwrap())].try_into()?))),
                     }),
                     ContractData(LedgerKeyContractData {
                         contract_id: contract_id.clone(),
-                        key: ScVal::Symbol("Metadata".try_into().unwrap()),
+                        key: ScVal::Object(Some(ScObject::Vec(vec![ScVal::Symbol("Metadata".try_into().unwrap())].try_into()?))),
                     }),
                 ]
                 .try_into()?,

--- a/src/token/create.rs
+++ b/src/token/create.rs
@@ -367,21 +367,23 @@ fn build_init_op(contract_id: &Hash, parameters: ScVec) -> Result<Operation, Err
             function: HostFunction::InvokeContract,
             parameters,
             footprint: LedgerFootprint {
-                read_only: vec![
-                    ContractData(LedgerKeyContractData {
-                        contract_id: contract_id.clone(),
-                        key: ScVal::Static(LedgerKeyContractCode),
-                    }),
-                ]
+                read_only: vec![ContractData(LedgerKeyContractData {
+                    contract_id: contract_id.clone(),
+                    key: ScVal::Static(LedgerKeyContractCode),
+                })]
                 .try_into()?,
                 read_write: vec![
                     ContractData(LedgerKeyContractData {
                         contract_id: contract_id.clone(),
-                        key: ScVal::Object(Some(ScObject::Vec(vec![ScVal::Symbol("Admin".try_into().unwrap())].try_into()?))),
+                        key: ScVal::Object(Some(ScObject::Vec(
+                            vec![ScVal::Symbol("Admin".try_into().unwrap())].try_into()?,
+                        ))),
                     }),
                     ContractData(LedgerKeyContractData {
                         contract_id: contract_id.clone(),
-                        key: ScVal::Object(Some(ScObject::Vec(vec![ScVal::Symbol("Metadata".try_into().unwrap())].try_into()?))),
+                        key: ScVal::Object(Some(ScObject::Vec(
+                            vec![ScVal::Symbol("Metadata".try_into().unwrap())].try_into()?,
+                        ))),
                     }),
                 ]
                 .try_into()?,

--- a/src/token/create.rs
+++ b/src/token/create.rs
@@ -367,7 +367,13 @@ fn build_init_op(contract_id: &Hash, parameters: ScVec) -> Result<Operation, Err
             function: HostFunction::InvokeContract,
             parameters,
             footprint: LedgerFootprint {
-                read_only: VecM::default(),
+                read_only: vec![
+                    ContractData(LedgerKeyContractData {
+                        contract_id: contract_id.clone(),
+                        key: ScVal::Static(LedgerKeyContractCode),
+                    }),
+                ]
+                .try_into()?,
                 read_write: vec![
                     ContractData(LedgerKeyContractData {
                         contract_id: contract_id.clone(),


### PR DESCRIPTION
### What

- Add the contractCode ledger entry to the token init op footprint.
- Fix type of the Admin & Metadata footprint entries

### Why

- Fixes https://github.com/stellar/go/issues/4627

### Note

I fixed this by getting the TxEnvelope from horizon, and running `simulateTransaction` with it. Then used laboratory to compare the submitted footprint with the simulated one.