### PR TITLE
Output the ledger footprint when invoking

### DIFF
--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -319,10 +319,7 @@ impl Cmd {
         let footprint = LedgerFootprint::from_xdr_base64(simulation_response.footprint)?;
 
         if self.footprint {
-            eprintln!(
-                "Footprint: {:?}",
-                serde_json::to_string(&footprint).unwrap(),
-            );
+            eprintln!("Footprint: {}", serde_json::to_string(&footprint).unwrap(),);
         }
 
         // Send the final transaction with the actual footprint


### PR DESCRIPTION
### What
Output the ledger footprint when invoking as JSON.

### Why
To provide some access, albeit limited, to finding out what footprint is required for different invocations.

Maybe make it easier to debug some situations like https://github.com/stellar/soroban-cli/pull/201.

In terms of what format to output it? I considered XDR, Rust values, and JSON. None are great because of how binaries and contract IDs get formatted, so I just picked JSON. We really need to improve our formatting of these values.