### PR TITLE
Add back ability to use --wasm in remote invoke

### DIFF
--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -42,7 +42,7 @@ pub struct Cmd {
     )]
     account_id: StrkeyPublicKeyEd25519,
 
-    /// WASM file to deploy to the contract ID and invoke
+    /// WASM file of the contract to invoke (if using sandbox will deploy this file)
     #[clap(long, parse(from_os_str))]
     wasm: Option<std::path::PathBuf>,
     /// Function name to execute

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -5,8 +5,8 @@ use clap::Parser;
 use hex::FromHexError;
 use soroban_env_host::xdr::{
     InvokeHostFunctionOp, LedgerFootprint, Memo, MuxedAccount, Operation, OperationBody,
-    Preconditions, ScContractCode, ScStatic, ScVec, SequenceNumber, Transaction,
-    TransactionEnvelope, TransactionExt, VecM,
+    Preconditions, ScStatic, ScVec, SequenceNumber, Transaction, TransactionEnvelope,
+    TransactionExt, VecM,
 };
 use soroban_env_host::{
     budget::{Budget, CostType},
@@ -43,7 +43,7 @@ pub struct Cmd {
     account_id: StrkeyPublicKeyEd25519,
 
     /// WASM file to deploy to the contract ID and invoke
-    #[clap(long, parse(from_os_str), conflicts_with = "rpc-url")]
+    #[clap(long, parse(from_os_str))]
     wasm: Option<std::path::PathBuf>,
     /// Function name to execute
     #[clap(long = "fn")]
@@ -276,19 +276,25 @@ impl Cmd {
         let fee: u32 = 100;
         let sequence = account_details.sequence.parse::<i64>()?;
 
-        // Get the contract from the network
-        let contract_data = client
-            .get_contract_data(
-                &hex::encode(contract_id),
-                ScVal::Static(ScStatic::LedgerKeyContractCode),
-            )
-            .await?;
-
-        let wasm = match ScVal::from_xdr_base64(contract_data.xdr)? {
-            ScVal::Object(Some(ScObject::ContractCode(ScContractCode::Wasm(bytes)))) => {
-                bytes.to_vec()
+        // Get the contract
+        let wasm = if let Some(f) = &self.wasm {
+            // Get the contract from a file
+            fs::read(f).map_err(|e| Error::CannotReadContractFile {
+                filepath: f.clone(),
+                error: e,
+            })?
+        } else {
+            // Get the contract from the network
+            let contract_data = client
+                .get_contract_data(
+                    &hex::encode(contract_id),
+                    ScVal::Static(ScStatic::LedgerKeyContractCode),
+                )
+                .await?;
+            match ScVal::from_xdr_base64(contract_data.xdr)? {
+                ScVal::Object(Some(ScObject::Bytes(bytes))) => bytes.to_vec(),
+                scval => return Err(Error::UnexpectedContractCodeDataType(scval)),
             }
-            scval => return Err(Error::UnexpectedContractCodeDataType(scval)),
         };
 
         // Get the ledger footprint

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -5,8 +5,8 @@ use clap::Parser;
 use hex::FromHexError;
 use soroban_env_host::xdr::{
     InvokeHostFunctionOp, LedgerFootprint, Memo, MuxedAccount, Operation, OperationBody,
-    Preconditions, ScStatic, ScVec, SequenceNumber, Transaction, TransactionEnvelope,
-    TransactionExt, VecM,
+    Preconditions, ScContractCode, ScStatic, ScVec, SequenceNumber, Transaction,
+    TransactionEnvelope, TransactionExt, VecM,
 };
 use soroban_env_host::{
     budget::{Budget, CostType},

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -292,7 +292,9 @@ impl Cmd {
                 )
                 .await?;
             match ScVal::from_xdr_base64(contract_data.xdr)? {
-                ScVal::Object(Some(ScObject::Bytes(bytes))) => bytes.to_vec(),
+                ScVal::Object(Some(ScObject::ContractCode(ScContractCode::Wasm(bytes)))) => {
+                    bytes.to_vec()
+                }
                 scval => return Err(Error::UnexpectedContractCodeDataType(scval)),
             }
         };


### PR DESCRIPTION
### What
Add back ability to use --wasm in remote invoke.

### Why
It was removed in https://github.com/stellar/soroban-cli/pull/205, but we don't need to remove it.

The diff of #205 and #206 combined becomes:

```diff
--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -5,8 +5,8 @@ use clap::Parser;
 use hex::FromHexError;
 use soroban_env_host::xdr::{
     InvokeHostFunctionOp, LedgerFootprint, Memo, MuxedAccount, Operation, OperationBody,
-    Preconditions, ScStatic, ScVec, SequenceNumber, Transaction, TransactionEnvelope,
-    TransactionExt, VecM,
+    Preconditions, ScContractCode, ScStatic, ScVec, SequenceNumber, Transaction,
+    TransactionEnvelope, TransactionExt, VecM,
 };
 use soroban_env_host::{
     budget::{Budget, CostType},
@@ -42,7 +42,7 @@ pub struct Cmd {
     )]
     account_id: StrkeyPublicKeyEd25519,
 
-    /// WASM file to deploy to the contract ID and invoke
+    /// WASM file of the contract to invoke (if using sandbox will deploy this file)
     #[clap(long, parse(from_os_str))]
     wasm: Option<std::path::PathBuf>,
     /// Function name to execute
@@ -292,7 +292,9 @@ impl Cmd {
                 )
                 .await?;
             match ScVal::from_xdr_base64(contract_data.xdr)? {
-                ScVal::Object(Some(ScObject::Bytes(bytes))) => bytes.to_vec(),
+                ScVal::Object(Some(ScObject::ContractCode(ScContractCode::Wasm(bytes)))) => {
+                    bytes.to_vec()
+                }
                 scval => return Err(Error::UnexpectedContractCodeDataType(scval)),
             }
         };
```