### PR TITLE
Group sandbox and rpc options together

### DIFF
--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -17,10 +17,7 @@ use soroban_env_host::HostError;
 
 use crate::rpc::{self, Client};
 use crate::snapshot::{self, get_default_ledger_info};
-use crate::utils;
-
-const HEADING_SANDBOX: &str = "OPTIONS (SANDBOX)";
-const HEADING_RPC: &str = "OPTIONS (RPC)";
+use crate::{utils, HEADING_RPC, HEADING_SANDBOX};
 
 #[derive(Parser, Debug)]
 pub struct Cmd {

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -50,6 +50,13 @@ pub struct Cmd {
         help_heading = HEADING_RPC,
     )]
     secret_key: Option<String>,
+    /// Custom salt 32-byte salt for the token id
+    #[clap(
+        long,
+        conflicts_with_all = &["contract-id", "ledger-file"],
+        help_heading = HEADING_RPC,
+    )]
+    salt: Option<String>,
     /// RPC server endpoint
     #[clap(
         long,
@@ -67,14 +74,6 @@ pub struct Cmd {
         help_heading = HEADING_RPC,
     )]
     network_passphrase: Option<String>,
-
-    /// Custom salt 32-byte salt for the token id
-    #[clap(
-        long,
-        conflicts_with_all = &["contract-id", "ledger-file"],
-        help_heading = HEADING_RPC,
-    )]
-    salt: Option<String>,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -19,21 +19,29 @@ use crate::rpc::{self, Client};
 use crate::snapshot::{self, get_default_ledger_info};
 use crate::utils;
 
+const HEADING_SANDBOX: &str = "OPTIONS (SANDBOX)";
+const HEADING_RPC: &str = "OPTIONS (RPC)";
+
 #[derive(Parser, Debug)]
 pub struct Cmd {
-    /// Contract ID to deploy to (if using the sandbox)
-    #[clap(long = "id", conflicts_with = "rpc-url")]
+    /// Contract ID to deploy to
+    #[clap(
+        long = "id",
+        conflicts_with = "rpc-url",
+        help_heading = HEADING_SANDBOX,
+    )]
     contract_id: Option<String>,
     /// WASM file to deploy
     #[clap(long, parse(from_os_str))]
     wasm: std::path::PathBuf,
-    /// File to persist ledger state (if using the sandbox)
+    /// File to persist ledger state
     #[clap(
         long,
         parse(from_os_str),
         default_value = ".soroban/ledger.json",
         conflicts_with = "rpc-url",
-        env = "SOROBAN_LEDGER_FILE"
+        env = "SOROBAN_LEDGER_FILE",
+        help_heading = HEADING_SANDBOX,
     )]
     ledger_file: std::path::PathBuf,
     /// RPC server endpoint
@@ -42,20 +50,30 @@ pub struct Cmd {
         conflicts_with = "contract-id",
         requires = "secret-key",
         requires = "network-passphrase",
-        env = "SOROBAN_RPC_URL"
+        env = "SOROBAN_RPC_URL",
+        help_heading = HEADING_RPC,
     )]
     rpc_url: Option<String>,
     /// Secret 'S' key used to sign the transaction sent to the rpc server
-    #[clap(long = "secret-key", env = "SOROBAN_SECRET_KEY")]
+    #[clap(
+        long = "secret-key",
+        env = "SOROBAN_SECRET_KEY",
+        help_heading = HEADING_RPC,
+    )]
     secret_key: Option<String>,
     /// Network passphrase to sign the transaction sent to the rpc server
-    #[clap(long = "network-passphrase", env = "SOROBAN_NETWORK_PASSPHRASE")]
+    #[clap(
+        long = "network-passphrase",
+        env = "SOROBAN_NETWORK_PASSPHRASE",
+        help_heading = HEADING_RPC,
+    )]
     network_passphrase: Option<String>,
 
     /// Custom salt 32-byte salt for the token id
     #[clap(
         long,
         conflicts_with_all = &["contract-id", "ledger-file"],
+        help_heading = HEADING_RPC,
     )]
     salt: Option<String>,
 }

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -21,6 +21,10 @@ use crate::{utils, HEADING_RPC, HEADING_SANDBOX};
 
 #[derive(Parser, Debug)]
 pub struct Cmd {
+    /// WASM file to deploy
+    #[clap(long, parse(from_os_str))]
+    wasm: std::path::PathBuf,
+
     /// Contract ID to deploy to
     #[clap(
         long = "id",
@@ -28,9 +32,6 @@ pub struct Cmd {
         help_heading = HEADING_SANDBOX,
     )]
     contract_id: Option<String>,
-    /// WASM file to deploy
-    #[clap(long, parse(from_os_str))]
-    wasm: std::path::PathBuf,
     /// File to persist ledger state
     #[clap(
         long,
@@ -41,6 +42,14 @@ pub struct Cmd {
         help_heading = HEADING_SANDBOX,
     )]
     ledger_file: std::path::PathBuf,
+
+    /// Secret 'S' key used to sign the transaction sent to the rpc server
+    #[clap(
+        long = "secret-key",
+        env = "SOROBAN_SECRET_KEY",
+        help_heading = HEADING_RPC,
+    )]
+    secret_key: Option<String>,
     /// RPC server endpoint
     #[clap(
         long,
@@ -51,13 +60,6 @@ pub struct Cmd {
         help_heading = HEADING_RPC,
     )]
     rpc_url: Option<String>,
-    /// Secret 'S' key used to sign the transaction sent to the rpc server
-    #[clap(
-        long = "secret-key",
-        env = "SOROBAN_SECRET_KEY",
-        help_heading = HEADING_RPC,
-    )]
-    secret_key: Option<String>,
     /// Network passphrase to sign the transaction sent to the rpc server
     #[clap(
         long = "network-passphrase",

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -28,6 +28,7 @@ use crate::{
     strval::{self, StrValError},
     utils,
 };
+use crate::{HEADING_RPC, HEADING_SANDBOX};
 
 #[derive(Parser, Debug)]
 pub struct Cmd {
@@ -35,7 +36,13 @@ pub struct Cmd {
     #[clap(
         long = "account",
         default_value = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
-        conflicts_with = "rpc-url"
+        // TODO: Allow account to be specified with rpc-url/secret-key and use
+        // the value for the source account when specified instead of using the
+        // secret keys public key. Remove the help heading as part of this.
+        // This will make this field work the same way the create token command
+        // does.
+        conflicts_with = "rpc-url",
+        help_heading = HEADING_RPC,
     )]
     account_id: StrkeyPublicKeyEd25519,
     /// Contract ID to invoke
@@ -65,7 +72,8 @@ pub struct Cmd {
         parse(from_os_str),
         default_value(".soroban/ledger.json"),
         conflicts_with = "rpc-url",
-        env = "SOROBAN_LEDGER_FILE"
+        env = "SOROBAN_LEDGER_FILE",
+        help_heading = HEADING_SANDBOX,
     )]
     ledger_file: std::path::PathBuf,
     /// RPC server endpoint
@@ -74,17 +82,24 @@ pub struct Cmd {
         conflicts_with = "account-id",
         requires = "secret-key",
         requires = "network-passphrase",
-        env = "SOROBAN_RPC_URL"
+        env = "SOROBAN_RPC_URL",
+        help_heading = HEADING_RPC,
     )]
     rpc_url: Option<String>,
     /// Secret 'S' key used to sign the transaction sent to the rpc server
-    #[clap(long = "secret-key", requires = "rpc-url", env = "SOROBAN_SECRET_KEY")]
+    #[clap(
+        long = "secret-key",
+        requires = "rpc-url",
+        env = "SOROBAN_SECRET_KEY",
+        help_heading = HEADING_RPC,
+    )]
     secret_key: Option<String>,
     /// Network passphrase to sign the transaction sent to the rpc server
     #[clap(
         long = "network-passphrase",
         requires = "rpc-url",
-        env = "SOROBAN_NETWORK_PASSPHRASE"
+        env = "SOROBAN_NETWORK_PASSPHRASE",
+        help_heading = HEADING_RPC,
     )]
     network_passphrase: Option<String>,
 }

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -32,19 +32,6 @@ use crate::{HEADING_RPC, HEADING_SANDBOX};
 
 #[derive(Parser, Debug)]
 pub struct Cmd {
-    /// Account ID to invoke as
-    #[clap(
-        long = "account",
-        default_value = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
-        // TODO: Allow account to be specified with rpc-url/secret-key and use
-        // the value for the source account when specified instead of using the
-        // secret keys public key. Remove the help heading as part of this.
-        // This will make this field work the same way the create token command
-        // does.
-        conflicts_with = "rpc-url",
-        help_heading = HEADING_RPC,
-    )]
-    account_id: StrkeyPublicKeyEd25519,
     /// Contract ID to invoke
     #[clap(long = "id")]
     contract_id: String,
@@ -66,6 +53,15 @@ pub struct Cmd {
     /// Output the footprint to stderr
     #[clap(long = "footprint")]
     footprint: bool,
+
+    /// Account ID to invoke as
+    #[clap(
+        long = "account",
+        default_value = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        conflicts_with = "rpc-url",
+        help_heading = HEADING_SANDBOX,
+    )]
+    account_id: StrkeyPublicKeyEd25519,
     /// File to persist ledger state
     #[clap(
         long,
@@ -76,6 +72,15 @@ pub struct Cmd {
         help_heading = HEADING_SANDBOX,
     )]
     ledger_file: std::path::PathBuf,
+
+    /// Secret 'S' key used to sign the transaction sent to the rpc server
+    #[clap(
+        long = "secret-key",
+        requires = "rpc-url",
+        env = "SOROBAN_SECRET_KEY",
+        help_heading = HEADING_RPC,
+    )]
+    secret_key: Option<String>,
     /// RPC server endpoint
     #[clap(
         long,
@@ -86,14 +91,6 @@ pub struct Cmd {
         help_heading = HEADING_RPC,
     )]
     rpc_url: Option<String>,
-    /// Secret 'S' key used to sign the transaction sent to the rpc server
-    #[clap(
-        long = "secret-key",
-        requires = "rpc-url",
-        env = "SOROBAN_SECRET_KEY",
-        help_heading = HEADING_RPC,
-    )]
-    secret_key: Option<String>,
     /// Network passphrase to sign the transaction sent to the rpc server
     #[clap(
         long = "network-passphrase",

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,9 @@ mod utils;
 mod version;
 mod xdr;
 
+const HEADING_SANDBOX: &str = "OPTIONS (SANDBOX)";
+const HEADING_RPC: &str = "OPTIONS (RPC)";
+
 #[derive(Parser, Debug)]
 #[clap(
     name = "soroban",

--- a/src/read.rs
+++ b/src/read.rs
@@ -16,7 +16,7 @@ use soroban_env_host::{
 use crate::{
     snapshot,
     strval::{self, StrValError},
-    utils,
+    utils, HEADING_SANDBOX,
 };
 
 #[derive(Parser, Debug)]
@@ -38,7 +38,8 @@ pub struct Cmd {
         long,
         parse(from_os_str),
         default_value(".soroban/ledger.json"),
-        env = "SOROBAN_LEDGER_FILE"
+        env = "SOROBAN_LEDGER_FILE",
+        help_heading = HEADING_SANDBOX,
     )]
     ledger_file: std::path::PathBuf,
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -33,6 +33,7 @@ pub struct Cmd {
     /// Type of output to generate
     #[clap(long, arg_enum, default_value("string"))]
     output: Output,
+
     /// File to persist ledger state
     #[clap(
         long,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -31,6 +31,7 @@ pub struct Cmd {
     /// Port to listen for requests on.
     #[clap(long, default_value("8080"))]
     port: u16,
+
     /// File to persist ledger state
     #[clap(
         long,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -20,11 +20,11 @@ use stellar_strkey::StrkeyPublicKeyEd25519;
 use tokio::sync::Mutex;
 use warp::{http::Response, Filter};
 
-use crate::jsonrpc;
 use crate::network::SANDBOX_NETWORK_PASSPHRASE;
 use crate::snapshot;
 use crate::strval::StrValError;
 use crate::utils::{self, create_ledger_footprint};
+use crate::{jsonrpc, HEADING_SANDBOX};
 
 #[derive(Parser, Debug)]
 pub struct Cmd {
@@ -36,7 +36,8 @@ pub struct Cmd {
         long,
         parse(from_os_str),
         default_value(".soroban/ledger.json"),
-        env = "SOROBAN_LEDGER_FILE"
+        env = "SOROBAN_LEDGER_FILE",
+        help_heading = HEADING_SANDBOX,
     )]
     ledger_file: PathBuf,
 }

--- a/src/token/create.rs
+++ b/src/token/create.rs
@@ -60,19 +60,15 @@ pub struct Cmd {
     /// Administrator account for the token, will default to --secret-key if not set
     #[clap(long)]
     admin: Option<StrkeyPublicKeyEd25519>,
-
     /// Number of decimal places for the token
     #[clap(long, default_value = "7")]
     decimal: u32,
-
     /// Long name of the token, e.g. "Stellar Lumens"
     #[clap(long)]
     name: String,
-
     /// Short name of the token, e.g. "XLM"
     #[clap(long)]
     symbol: String,
-
     /// Custom salt 32-byte salt for the token id
     #[clap(
         long,

--- a/src/token/create.rs
+++ b/src/token/create.rs
@@ -20,7 +20,7 @@ use stellar_strkey::StrkeyPublicKeyEd25519;
 
 use crate::{
     rpc::{Client, Error as SorobanRpcError},
-    snapshot, utils,
+    snapshot, utils, HEADING_RPC, HEADING_SANDBOX,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -86,7 +86,8 @@ pub struct Cmd {
         parse(from_os_str),
         default_value = ".soroban/ledger.json",
         conflicts_with = "rpc-url",
-        env = "SOROBAN_LEDGER_FILE"
+        env = "SOROBAN_LEDGER_FILE",
+        help_heading = HEADING_SANDBOX,
     )]
     ledger_file: std::path::PathBuf,
 
@@ -96,14 +97,23 @@ pub struct Cmd {
         conflicts_with = "ledger-file",
         requires = "secret-key",
         requires = "network-passphrase",
-        env = "SOROBAN_RPC_URL"
+        env = "SOROBAN_RPC_URL",
+        help_heading = HEADING_RPC,
     )]
     rpc_url: Option<String>,
     /// Secret key to sign the transaction sent to the rpc server
-    #[clap(long = "secret-key", env = "SOROBAN_SECRET_KEY")]
+    #[clap(
+        long = "secret-key",
+        env = "SOROBAN_SECRET_KEY",
+        help_heading = HEADING_RPC,
+    )]
     secret_key: Option<String>,
     /// Network passphrase to sign the transaction sent to the rpc server
-    #[clap(long = "network-passphrase", env = "SOROBAN_NETWORK_PASSPHRASE")]
+    #[clap(
+        long = "network-passphrase",
+        env = "SOROBAN_NETWORK_PASSPHRASE",
+        help_heading = HEADING_RPC,
+    )]
     network_passphrase: Option<String>,
 }
 

--- a/src/token/wrap.rs
+++ b/src/token/wrap.rs
@@ -19,7 +19,7 @@ use stellar_strkey::StrkeyPublicKeyEd25519;
 
 use crate::{
     rpc::{Client, Error as SorobanRpcError},
-    snapshot, utils,
+    snapshot, utils, HEADING_RPC, HEADING_SANDBOX,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -68,7 +68,8 @@ pub struct Cmd {
         parse(from_os_str),
         default_value = ".soroban/ledger.json",
         conflicts_with = "rpc-url",
-        env = "SOROBAN_LEDGER_FILE"
+        env = "SOROBAN_LEDGER_FILE",
+        help_heading = HEADING_SANDBOX,
     )]
     ledger_file: std::path::PathBuf,
 
@@ -78,14 +79,23 @@ pub struct Cmd {
         conflicts_with = "ledger-file",
         requires = "secret-key",
         requires = "network-passphrase",
-        env = "SOROBAN_RPC_URL"
+        env = "SOROBAN_RPC_URL",
+        help_heading = HEADING_RPC,
     )]
     rpc_url: Option<String>,
     /// Secret key to sign the transaction sent to the rpc server
-    #[clap(long = "secret-key", env = "SOROBAN_SECRET_KEY")]
+    #[clap(
+        long = "secret-key",
+        env = "SOROBAN_SECRET_KEY",
+        help_heading = HEADING_RPC,
+    )]
     secret_key: Option<String>,
     /// Network passphrase to sign the transaction sent to the rpc server
-    #[clap(long = "network-passphrase", env = "SOROBAN_NETWORK_PASSPHRASE")]
+    #[clap(
+        long = "network-passphrase",
+        env = "SOROBAN_NETWORK_PASSPHRASE",
+        help_heading = HEADING_RPC,
+    )]
     network_passphrase: Option<String>,
 }
 

--- a/src/token/wrap.rs
+++ b/src/token/wrap.rs
@@ -73,6 +73,13 @@ pub struct Cmd {
     )]
     ledger_file: std::path::PathBuf,
 
+    /// Secret key to sign the transaction sent to the rpc server
+    #[clap(
+        long = "secret-key",
+        env = "SOROBAN_SECRET_KEY",
+        help_heading = HEADING_RPC,
+    )]
+    secret_key: Option<String>,
     /// RPC server endpoint
     #[clap(
         long,
@@ -83,13 +90,6 @@ pub struct Cmd {
         help_heading = HEADING_RPC,
     )]
     rpc_url: Option<String>,
-    /// Secret key to sign the transaction sent to the rpc server
-    #[clap(
-        long = "secret-key",
-        env = "SOROBAN_SECRET_KEY",
-        help_heading = HEADING_RPC,
-    )]
-    secret_key: Option<String>,
     /// Network passphrase to sign the transaction sent to the rpc server
     #[clap(
         long = "network-passphrase",


### PR DESCRIPTION
### What
Group sandbox and rpc options together in the help output.

### Why
We have issue that the CLI is confusing to use because of the multiple sets of options. We have longer running discussions about how we might tackle that longer term. Grouping the options in the help is a low hanging fruit way we can improve the readability of the help. This isn't intended to solve the issue once and for all, but it'll hold us over.

### Examples
<img width="877" alt="Screen Shot 2022-10-07 at 1 01 09 PM" src="https://user-images.githubusercontent.com/351529/194644564-edf3620a-555d-42aa-8783-7e3fb7e0509c.png">
<img width="877" alt="Screen Shot 2022-10-07 at 1 06 18 PM" src="https://user-images.githubusercontent.com/351529/194644571-b7fbbe8d-ddd5-47c3-a694-23107f5ea12e.png">
<img width="877" alt="Screen Shot 2022-10-07 at 1 01 22 PM" src="https://user-images.githubusercontent.com/351529/194644581-4862d270-a39b-42db-acae-c9b0fbba1d80.png">
<img width="877" alt="Screen Shot 2022-10-07 at 1 01 38 PM" src="https://user-images.githubusercontent.com/351529/194644584-3a39c1e9-98ae-428e-841e-549503d63ec7.png">
<img width="877" alt="Screen Shot 2022-10-07 at 1 02 03 PM" src="https://user-images.githubusercontent.com/351529/194644587-f4b92643-841b-4fc7-99c4-f2a0b6e332b5.png">
<img width="877" alt="Screen Shot 2022-10-07 at 1 02 14 PM" src="https://user-images.githubusercontent.com/351529/194644590-fa1d6a6b-704e-43bd-9861-fe04b8807127.png">
