### PR TITLE
Fix the url the invoke client connects to for the rpc

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -88,7 +88,7 @@ impl Client {
     }
 
     fn client(&self) -> Result<HttpClient, Error> {
-        let url = self.base_url.clone() + "/api/v1/jsonrpc";
+        let url = self.base_url.clone();
         let mut headers = HeaderMap::new();
         headers.insert("X-Client-Name", "soroban-cli".parse().unwrap());
         let version = VERSION.unwrap_or("devel");

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -113,7 +113,7 @@ impl Cmd {
         let routes = jsonrpc_route.with(cors);
 
         let addr: SocketAddr = ([127, 0, 0, 1], self.port).into();
-        println!("Listening on: {}", addr);
+        println!("Listening on: {}/soroban/rpc", addr);
         warp::serve(routes).run(addr).await;
         Ok(())
     }


### PR DESCRIPTION
### What
Change the URL the invoke client connects to, to not append the rpc path and rely on the user providing the full path at the command line. Also prints the served path to the command line so people know what it is.

### Why
https://github.com/stellar/soroban-cli/pull/211 changed the path that get served to be /soroban/rpc instead of /api/v1/jsonrpc, to match soroban-rpc.

However, the soroban invoke command still sends requests to /api/v1/jsonrpc. This doesn’t seem to matter for the real soroban-rpc server, but the invoke command doesn’t work with the local serve anymore.