### PR TITLE
Retroactively add binaries to the release of v0.1.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ name: Publish
 on:
   release:
     types: [published]
+  push:
+    branches: ['release/v0.1.2']
 
 jobs:
 
@@ -10,3 +12,54 @@ jobs:
     uses: stellar/actions/.github/workflows/rust-publish.yml@main
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  upload:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          # TODO: Re-enable when soroban-cli can compile for Linux aarch64.
+          # - os: ubuntu-latest
+          #   target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          # TODO: Re-enable when this job is updated to support Windows.
+          # - os: windows-latest
+          #   target: x86_64-pc-windows-msvc
+          #   ext: .exe
+    runs-on: ${{ matrix.os }}
+    env:
+      # VERSION: '${{ github.event.release.release.name }}'
+      VERSION: '0.1.2'
+      NAME: 'soroban-cli-0.1.2-${{ matrix.target }}'
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update
+    - run: rustup target add ${{ matrix.target }}
+    - name: Package
+      run: cargo package --no-verify
+    - name: Build
+      run: |
+        cd target/package
+        tar xvfz soroban-cli-$VERSION.crate
+        cd soroban-cli-$VERSION
+        cargo build --target-dir=../.. --release --target ${{ matrix.target }}
+    - name: Compress
+      run: |
+        cd target/${{ matrix.target }}/release
+        tar czvf $NAME.tar.gz soroban${{ matrix.ext }}
+    - name: Upload
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const fs = require('fs');
+          await github.rest.repos.uploadReleaseAsset({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            release_id: 79496745, // ${{ github.event.release.release.id }}
+            name: '${{ env.NAME }}.tar.gz',
+            data: fs.readFileSync('target/${{ matrix.target }}/release/${{ env.NAME }}.tar.gz'),
+          });


### PR DESCRIPTION
### What

Retroactively add binaries to the release of v0.1.2.

### Why

For installs without building from source.

The main reason to add this is so that we can install soroban-cli into places that are inconvenient to do a build from source. For example, when installing soroban-cli into a repl.it, the build consumes so much disk space that it often fails to install.

I've added this process to the existing publish action because I think it will be beneficial if we lead into using this same process for any Rust project that has binaries. There might be some growing pains with that, if for example we have tools we only want to release on specific architectures, etc. I think we can tackle those problems when they arise rather than try to presolve for them.

I'm not making a new release just to get binaries because it would be helpful if the binaries we release for use in things like repl.it match the release everyone else is already using.


Dependent on https://github.com/stellar/actions/pull/32