### PR TITLE
Publish binaries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,3 +10,53 @@ jobs:
     uses: stellar/actions/.github/workflows/rust-publish.yml@main
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  upload:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          # TODO: Re-enable when soroban-cli can compile for Linux aarch64.
+          # - os: ubuntu-latest
+          #   target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          # TODO: Re-enable when this job is updated to support Windows.
+          # - os: windows-latest
+          #   target: x86_64-pc-windows-msvc
+          #   ext: .exe
+    runs-on: ${{ matrix.os }}
+    env:
+      VERSION: '${{ github.event.release.release.name }}'
+      NAME: 'soroban-cli-${{ github.event.release.release.name }}-${{ matrix.target }}'
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update
+    - run: rustup target add ${{ matrix.target }}
+    - name: Package
+      run: cargo package --no-verify
+    - name: Build
+      run: |
+        cd target/package
+        tar xvfz soroban-cli-$VERSION.crate
+        cd soroban-cli-$VERSION
+        cargo build --target-dir=../.. --release --target ${{ matrix.target }}
+    - name: Compress
+      run: |
+        cd target/${{ matrix.target }}/release
+        tar czvf $NAME.tar.gz soroban${{ matrix.ext }}
+    - name: Upload
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const fs = require('fs');
+          await github.rest.repos.uploadReleaseAsset({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            release_id: ${{ github.event.release.release.id }},
+            name: '${{ env.NAME }}.tar.gz',
+            data: fs.readFileSync('target/${{ matrix.target }}/release/${{ env.NAME }}.tar.gz'),
+          });

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,10 +44,6 @@ jobs:
         tar xvfz soroban-cli-$VERSION.crate
         cd soroban-cli-$VERSION
         cargo build --target-dir=../.. --release --target ${{ matrix.target }}
-    - name: Compress
-      run: |
-        cd target/${{ matrix.target }}/release
-        tar czvf $NAME.tar.gz soroban${{ matrix.ext }}
     - name: Upload
       uses: actions/github-script@v6
       with:
@@ -57,6 +53,6 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             release_id: ${{ github.event.release.release.id }},
-            name: '${{ env.NAME }}.tar.gz',
-            data: fs.readFileSync('target/${{ matrix.target }}/release/${{ env.NAME }}.tar.gz'),
+            name: '${{ env.NAME }}${{ matrix.ext }}',
+            data: fs.readFileSync('target/${{ matrix.target }}/release/soroban${{ matrix.ext }}'),
           });


### PR DESCRIPTION
### What

Publish binaries.

### Why

For installs without building from source.

This doesn't have a huge use, given that most people can install soroban-cli using cargo, and most people who need to install it will probably already have cargo installed because it's required for developing contracts.

But this has use in some places where it is difficult to install from source. For example, when installing soroban-cli into a repl.it, the build consumes so much disk space that it often fails to install.

### Known limitations

There's plenty of things we can improve about this. For example, we should publish binaries for Windows and Linux-aarch64. Also, we will probably subsume this into the shared publish.yml workflow that lives in the stellar/actions repo, but for now this will do.
