### PR TITLE
Fix jsonrpc compliance issue #151

### DIFF
--- a/src/serve.rs
+++ b/src/serve.rs
@@ -142,7 +142,7 @@ async fn handler(
     }
     let result = match (request.method.as_str(), request.params) {
         ("getAccount", Some(Requests::StringArg(b))) => get_account(b),
-        ("getHealth", Some(Requests::NoArg())) => Ok(get_health()),
+        ("getHealth", Some(Requests::NoArg()) | None) => Ok(get_health()),
         ("getContractData", Some(Requests::GetContractData((contract_id, key)))) => {
             get_contract_data(&contract_id, key, &ledger_file)
         }


### PR DESCRIPTION
### What

Allow missing params list for `getHealth` method.

### Why

Fixes #151

### Known limitations

[TODO or N/A]
