### PR TITLE
Fix publish binary ci job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,8 +32,8 @@ jobs:
             ext: .exe
     runs-on: ${{ matrix.os }}
     env:
-      VERSION: '${{ github.event.release.release.name }}'
-      NAME: 'soroban-cli-${{ github.event.release.release.name }}-${{ matrix.target }}'
+      VERSION: '${{ github.event.release.name }}'
+      NAME: 'soroban-cli-${{ github.event.release.name }}-${{ matrix.target }}'
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
@@ -62,7 +62,7 @@ jobs:
           await github.rest.repos.uploadReleaseAsset({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            release_id: ${{ github.event.release.release.id }},
+            release_id: ${{ github.event.release.id }},
             name: '${{ env.NAME }}${{ matrix.ext }}',
             data: fs.readFileSync('target/${{ matrix.target }}/release/soroban${{ matrix.ext }}'),
           });


### PR DESCRIPTION
### What
Set the version from the release name.

### Why
The upload step in the release process is failing. See https://github.com/stellar/soroban-cli/actions/runs/3392390018.

The version wasn't being set correctly, and so was blank.