### PR TITLE
Lean on workspace inheritance for deps for development

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,9 +1829,18 @@ dependencies = [
 [[package]]
 name = "soroban-auth"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9218b5b9e66c664000e87750ad8199cd7e94b37afb592b079183cc9619aaba9e"
+dependencies = [
+ "soroban-sdk 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "soroban-auth"
+version = "0.2.1"
 source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0#4d2559c05f4846d11ae967764b031f297eeeb2d6"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1856,11 +1865,11 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "soroban-auth",
- "soroban-env-host",
- "soroban-spec",
+ "soroban-auth 0.2.1 (git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0)",
+ "soroban-env-host 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=c04c2332)",
+ "soroban-spec 0.2.1 (git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0)",
  "soroban-token-spec",
- "stellar-strkey",
+ "stellar-strkey 0.0.6 (git+https://github.com/stellar/rs-stellar-strkey?rev=d1b68fd1)",
  "thiserror",
  "tokio",
  "warp",
@@ -1871,7 +1880,8 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c04c2332#c04c2332fd3ed3ee0e4b72c68c618c7f45f44ba1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85c804501b0f703626c19de336ed559f1a9f12c261777e4e6e066696afe40aa"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -1882,10 +1892,35 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c04c2332#c04c2332fd3ed3ee0e4b72c68c618c7f45f44ba1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e315e428ca52c33798e21b969cc59c06724303466ae36865a1c30e221753b95c"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
+]
+
+[[package]]
+name = "soroban-env-host"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8905e033f3b1c5e756a5cadd184e7e8cc449ec6dd16a5a5dd0017b86c8a1d99"
+dependencies = [
+ "backtrace",
+ "dyn-fmt",
+ "ed25519-dalek",
+ "hex",
+ "im-rc",
+ "log",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "sha2 0.10.6",
+ "soroban-env-common",
+ "soroban-native-sdk-macros",
+ "soroban-wasmi",
+ "static_assertions",
+ "tinyvec",
 ]
 
 [[package]]
@@ -1914,7 +1949,8 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c04c2332#c04c2332fd3ed3ee0e4b72c68c618c7f45f44ba1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63b23eda217f8fc531ed46ecc25020512942d51ed437b6075022f77fee5f847"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1926,12 +1962,27 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c04c2332#c04c2332fd3ed3ee0e4b72c68c618c7f45f44ba1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd4a4ccc67b7f8a049fc7b65f7fe015c9fc518b993ae7b58f26c70a0fd8afe64"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "soroban-sdk"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "541d2e344e84c26342b086b761679c88fd88987fe86a1f0fa60a7bf70dbcc9c4"
+dependencies = [
+ "bytes-lit",
+ "rand 0.8.5",
+ "soroban-env-guest",
+ "soroban-env-host 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-sdk-macros",
+ "stellar-strkey 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1943,15 +1994,16 @@ dependencies = [
  "ed25519-dalek",
  "rand 0.8.5",
  "soroban-env-guest",
- "soroban-env-host",
+ "soroban-env-host 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "soroban-sdk-macros",
- "stellar-strkey",
+ "stellar-strkey 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "soroban-sdk-macros"
 version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0#4d2559c05f4846d11ae967764b031f297eeeb2d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd2b3180bd1b45b24290f5ed3f36784ef4ac88a33275bd970238c56778efef8"
 dependencies = [
  "darling",
  "itertools",
@@ -1959,9 +2011,32 @@ dependencies = [
  "quote",
  "sha2 0.10.6",
  "soroban-env-common",
- "soroban-spec",
+ "soroban-spec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stellar-xdr",
  "syn",
+]
+
+[[package]]
+name = "soroban-spec"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05fa8fffbfe5023a4be81695442a70f770ee954ab82a8e7a8077674882859817"
+dependencies = [
+ "base64",
+ "darling",
+ "itertools",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.6",
+ "soroban-env-host 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stellar-xdr",
+ "syn",
+ "thiserror",
+ "wasmparser 0.88.0",
 ]
 
 [[package]]
@@ -1979,7 +2054,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "soroban-env-host",
+ "soroban-env-host 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "stellar-xdr",
  "syn",
  "thiserror",
@@ -1991,14 +2066,15 @@ name = "soroban-token-spec"
 version = "0.2.1"
 source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0#4d2559c05f4846d11ae967764b031f297eeeb2d6"
 dependencies = [
- "soroban-auth",
- "soroban-sdk",
+ "soroban-auth 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-sdk 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "soroban-wasmi"
 version = "0.16.0-soroban1"
-source = "git+https://github.com/stellar/wasmi?rev=d1ec0036#d1ec0036a002a14227b0b09117f0dc6182ae19e4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40812f1c94fb5cf57ba4cda81f9d17d18bac1dde377967d7ed907b6974627bf8"
 dependencies = [
  "soroban-wasmi_core",
  "spin 0.9.4",
@@ -2008,7 +2084,8 @@ dependencies = [
 [[package]]
 name = "soroban-wasmi_core"
 version = "0.16.0-soroban1"
-source = "git+https://github.com/stellar/wasmi?rev=d1ec0036#d1ec0036a002a14227b0b09117f0dc6182ae19e4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "468b788f0b3d4080a25243d3f452fb8413c31104bdf7612242b506d1229dfe85"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -2038,6 +2115,16 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-strkey"
 version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdc24a977b92cac2028693957b8e07ffb9249a0767a548391246c9fb964a439"
+dependencies = [
+ "base32",
+ "thiserror",
+]
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.6"
 source = "git+https://github.com/stellar/rs-stellar-strkey?rev=d1b68fd1#d1b68fd17cd4b04f370dcb1a1785d2eddca0a3c4"
 dependencies = [
  "base32",
@@ -2047,7 +2134,8 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.7"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=e88f9fa7#e88f9fa7ab3d0f54efb5cee8499ef9080f4d41f4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9295054553418f5d14d9099070acab34e8befab65aae102a3bae79b9cdf76ac0"
 dependencies = [
  "base64",
  "hex",
@@ -2142,14 +2230,14 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 name = "test_hello_world"
 version = "0.2.1"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 0.2.1 (git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0)",
 ]
 
 [[package]]
 name = "test_invoker_account_exists"
 version = "0.2.1"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 0.2.1 (git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,14 +1836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "soroban-auth"
-version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0#4d2559c05f4846d11ae967764b031f297eeeb2d6"
-dependencies = [
- "soroban-sdk 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "soroban-cli"
 version = "0.2.1"
 dependencies = [
@@ -1865,7 +1857,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "soroban-auth 0.2.1 (git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0)",
  "soroban-env-host 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=c04c2332)",
  "soroban-spec 0.2.1 (git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0)",
  "soroban-token-spec",
@@ -2066,7 +2057,7 @@ name = "soroban-token-spec"
 version = "0.2.1"
 source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0#4d2559c05f4846d11ae967764b031f297eeeb2d6"
 dependencies = [
- "soroban-auth 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-auth",
  "soroban-sdk 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,8 +1829,10 @@ dependencies = [
 [[package]]
 name = "soroban-auth"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9218b5b9e66c664000e87750ad8199cd7e94b37afb592b079183cc9619aaba9e"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1855,8 +1857,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "soroban-env-host",
- "soroban-spec",
+ "soroban-env-host 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=c04c2332)",
+ "soroban-spec 0.2.1 (git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0)",
  "soroban-token-spec",
  "stellar-strkey 0.0.6 (git+https://github.com/stellar/rs-stellar-strkey?rev=d1b68fd1)",
  "thiserror",
@@ -1869,19 +1871,11 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85c804501b0f703626c19de336ed559f1a9f12c261777e4e6e066696afe40aa"
 dependencies = [
- "soroban-env-macros 0.0.9",
+ "soroban-env-macros",
  "soroban-wasmi",
- "static_assertions",
- "stellar-xdr",
-]
-
-[[package]]
-name = "soroban-env-common"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=a613a0ce#a613a0ce7834b7286da766009ca3db633113e5f9"
-dependencies = [
- "soroban-env-macros 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=a613a0ce)",
  "static_assertions",
  "stellar-xdr",
 ]
@@ -1889,15 +1883,18 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=a613a0ce#a613a0ce7834b7286da766009ca3db633113e5f9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e315e428ca52c33798e21b969cc59c06724303466ae36865a1c30e221753b95c"
 dependencies = [
- "soroban-env-common 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=a613a0ce)",
+ "soroban-env-common",
  "static_assertions",
 ]
 
 [[package]]
 name = "soroban-env-host"
 version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8905e033f3b1c5e756a5cadd184e7e8cc449ec6dd16a5a5dd0017b86c8a1d99"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -1910,7 +1907,30 @@ dependencies = [
  "num-integer",
  "num-traits",
  "sha2 0.10.6",
- "soroban-env-common 0.0.9",
+ "soroban-env-common",
+ "soroban-native-sdk-macros",
+ "soroban-wasmi",
+ "static_assertions",
+ "tinyvec",
+]
+
+[[package]]
+name = "soroban-env-host"
+version = "0.0.9"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c04c2332#c04c2332fd3ed3ee0e4b72c68c618c7f45f44ba1"
+dependencies = [
+ "backtrace",
+ "dyn-fmt",
+ "ed25519-dalek",
+ "hex",
+ "im-rc",
+ "log",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "sha2 0.10.6",
+ "soroban-env-common",
  "soroban-native-sdk-macros",
  "soroban-wasmi",
  "static_assertions",
@@ -1920,18 +1940,8 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.9"
-dependencies = [
- "itertools",
- "proc-macro2",
- "quote",
- "stellar-xdr",
- "syn",
-]
-
-[[package]]
-name = "soroban-env-macros"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=a613a0ce#a613a0ce7834b7286da766009ca3db633113e5f9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63b23eda217f8fc531ed46ecc25020512942d51ed437b6075022f77fee5f847"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1943,6 +1953,8 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd4a4ccc67b7f8a049fc7b65f7fe015c9fc518b993ae7b58f26c70a0fd8afe64"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1953,27 +1965,44 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "541d2e344e84c26342b086b761679c88fd88987fe86a1f0fa60a7bf70dbcc9c4"
+dependencies = [
+ "bytes-lit",
+ "rand 0.8.5",
+ "soroban-env-guest",
+ "soroban-env-host 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-sdk-macros",
+ "stellar-strkey 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "soroban-sdk"
+version = "0.2.1"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0#4d2559c05f4846d11ae967764b031f297eeeb2d6"
 dependencies = [
  "bytes-lit",
  "ed25519-dalek",
  "rand 0.8.5",
  "soroban-env-guest",
- "soroban-env-host",
+ "soroban-env-host 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "soroban-sdk-macros",
- "stellar-strkey 0.0.6 (git+https://github.com/stellar/rs-stellar-strkey?rev=5e582a8b)",
+ "stellar-strkey 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "soroban-sdk-macros"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd2b3180bd1b45b24290f5ed3f36784ef4ac88a33275bd970238c56778efef8"
 dependencies = [
  "darling",
  "itertools",
  "proc-macro2",
  "quote",
  "sha2 0.10.6",
- "soroban-env-common 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=a613a0ce)",
- "soroban-spec",
+ "soroban-env-common",
+ "soroban-spec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stellar-xdr",
  "syn",
 ]
@@ -1981,6 +2010,8 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05fa8fffbfe5023a4be81695442a70f770ee954ab82a8e7a8077674882859817"
 dependencies = [
  "base64",
  "darling",
@@ -1992,7 +2023,29 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "soroban-env-host",
+ "soroban-env-host 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stellar-xdr",
+ "syn",
+ "thiserror",
+ "wasmparser 0.88.0",
+]
+
+[[package]]
+name = "soroban-spec"
+version = "0.2.1"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0#4d2559c05f4846d11ae967764b031f297eeeb2d6"
+dependencies = [
+ "base64",
+ "darling",
+ "itertools",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.6",
+ "soroban-env-host 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "stellar-xdr",
  "syn",
  "thiserror",
@@ -2002,15 +2055,17 @@ dependencies = [
 [[package]]
 name = "soroban-token-spec"
 version = "0.2.1"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0#4d2559c05f4846d11ae967764b031f297eeeb2d6"
 dependencies = [
  "soroban-auth",
- "soroban-sdk",
+ "soroban-sdk 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "soroban-wasmi"
 version = "0.16.0-soroban1"
-source = "git+https://github.com/stellar/wasmi?rev=d1ec0036#d1ec0036a002a14227b0b09117f0dc6182ae19e4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40812f1c94fb5cf57ba4cda81f9d17d18bac1dde377967d7ed907b6974627bf8"
 dependencies = [
  "soroban-wasmi_core",
  "spin 0.9.4",
@@ -2020,7 +2075,8 @@ dependencies = [
 [[package]]
 name = "soroban-wasmi_core"
 version = "0.16.0-soroban1"
-source = "git+https://github.com/stellar/wasmi?rev=d1ec0036#d1ec0036a002a14227b0b09117f0dc6182ae19e4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "468b788f0b3d4080a25243d3f452fb8413c31104bdf7612242b506d1229dfe85"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -2050,7 +2106,8 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-strkey"
 version = "0.0.6"
-source = "git+https://github.com/stellar/rs-stellar-strkey?rev=5e582a8b#5e582a8b48f85443df60dc78e2e98959862400d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdc24a977b92cac2028693957b8e07ffb9249a0767a548391246c9fb964a439"
 dependencies = [
  "base32",
  "thiserror",
@@ -2068,6 +2125,8 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9295054553418f5d14d9099070acab34e8befab65aae102a3bae79b9cdf76ac0"
 dependencies = [
  "base64",
  "hex",
@@ -2162,14 +2221,14 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 name = "test_hello_world"
 version = "0.2.1"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 0.2.1 (git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0)",
 ]
 
 [[package]]
 name = "test_invoker_account_exists"
 version = "0.2.1"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 0.2.1 (git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,10 +1829,8 @@ dependencies = [
 [[package]]
 name = "soroban-auth"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9218b5b9e66c664000e87750ad8199cd7e94b37afb592b079183cc9619aaba9e"
 dependencies = [
- "soroban-sdk 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1857,8 +1855,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "soroban-env-host 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=c04c2332)",
- "soroban-spec 0.2.1 (git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0)",
+ "soroban-env-host",
+ "soroban-spec",
  "soroban-token-spec",
  "stellar-strkey 0.0.6 (git+https://github.com/stellar/rs-stellar-strkey?rev=d1b68fd1)",
  "thiserror",
@@ -1871,11 +1869,19 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85c804501b0f703626c19de336ed559f1a9f12c261777e4e6e066696afe40aa"
 dependencies = [
- "soroban-env-macros",
+ "soroban-env-macros 0.0.9",
  "soroban-wasmi",
+ "static_assertions",
+ "stellar-xdr",
+]
+
+[[package]]
+name = "soroban-env-common"
+version = "0.0.9"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=a613a0ce#a613a0ce7834b7286da766009ca3db633113e5f9"
+dependencies = [
+ "soroban-env-macros 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=a613a0ce)",
  "static_assertions",
  "stellar-xdr",
 ]
@@ -1883,18 +1889,15 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e315e428ca52c33798e21b969cc59c06724303466ae36865a1c30e221753b95c"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=a613a0ce#a613a0ce7834b7286da766009ca3db633113e5f9"
 dependencies = [
- "soroban-env-common",
+ "soroban-env-common 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=a613a0ce)",
  "static_assertions",
 ]
 
 [[package]]
 name = "soroban-env-host"
 version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8905e033f3b1c5e756a5cadd184e7e8cc449ec6dd16a5a5dd0017b86c8a1d99"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -1907,30 +1910,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "sha2 0.10.6",
- "soroban-env-common",
- "soroban-native-sdk-macros",
- "soroban-wasmi",
- "static_assertions",
- "tinyvec",
-]
-
-[[package]]
-name = "soroban-env-host"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c04c2332#c04c2332fd3ed3ee0e4b72c68c618c7f45f44ba1"
-dependencies = [
- "backtrace",
- "dyn-fmt",
- "ed25519-dalek",
- "hex",
- "im-rc",
- "log",
- "num-bigint",
- "num-derive",
- "num-integer",
- "num-traits",
- "sha2 0.10.6",
- "soroban-env-common",
+ "soroban-env-common 0.0.9",
  "soroban-native-sdk-macros",
  "soroban-wasmi",
  "static_assertions",
@@ -1940,8 +1920,18 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63b23eda217f8fc531ed46ecc25020512942d51ed437b6075022f77fee5f847"
+dependencies = [
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "stellar-xdr",
+ "syn",
+]
+
+[[package]]
+name = "soroban-env-macros"
+version = "0.0.9"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=a613a0ce#a613a0ce7834b7286da766009ca3db633113e5f9"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1953,8 +1943,6 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4a4ccc67b7f8a049fc7b65f7fe015c9fc518b993ae7b58f26c70a0fd8afe64"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1965,44 +1953,27 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d2e344e84c26342b086b761679c88fd88987fe86a1f0fa60a7bf70dbcc9c4"
-dependencies = [
- "bytes-lit",
- "rand 0.8.5",
- "soroban-env-guest",
- "soroban-env-host 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "soroban-sdk-macros",
- "stellar-strkey 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "soroban-sdk"
-version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0#4d2559c05f4846d11ae967764b031f297eeeb2d6"
 dependencies = [
  "bytes-lit",
  "ed25519-dalek",
  "rand 0.8.5",
  "soroban-env-guest",
- "soroban-env-host 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-env-host",
  "soroban-sdk-macros",
- "stellar-strkey 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stellar-strkey 0.0.6 (git+https://github.com/stellar/rs-stellar-strkey?rev=5e582a8b)",
 ]
 
 [[package]]
 name = "soroban-sdk-macros"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd2b3180bd1b45b24290f5ed3f36784ef4ac88a33275bd970238c56778efef8"
 dependencies = [
  "darling",
  "itertools",
  "proc-macro2",
  "quote",
  "sha2 0.10.6",
- "soroban-env-common",
- "soroban-spec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-env-common 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=a613a0ce)",
+ "soroban-spec",
  "stellar-xdr",
  "syn",
 ]
@@ -2010,8 +1981,6 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05fa8fffbfe5023a4be81695442a70f770ee954ab82a8e7a8077674882859817"
 dependencies = [
  "base64",
  "darling",
@@ -2023,29 +1992,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "soroban-env-host 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "stellar-xdr",
- "syn",
- "thiserror",
- "wasmparser 0.88.0",
-]
-
-[[package]]
-name = "soroban-spec"
-version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0#4d2559c05f4846d11ae967764b031f297eeeb2d6"
-dependencies = [
- "base64",
- "darling",
- "itertools",
- "prettyplease",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2 0.10.6",
- "soroban-env-host 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-env-host",
  "stellar-xdr",
  "syn",
  "thiserror",
@@ -2055,17 +2002,15 @@ dependencies = [
 [[package]]
 name = "soroban-token-spec"
 version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0#4d2559c05f4846d11ae967764b031f297eeeb2d6"
 dependencies = [
  "soroban-auth",
- "soroban-sdk 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-sdk",
 ]
 
 [[package]]
 name = "soroban-wasmi"
 version = "0.16.0-soroban1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40812f1c94fb5cf57ba4cda81f9d17d18bac1dde377967d7ed907b6974627bf8"
+source = "git+https://github.com/stellar/wasmi?rev=d1ec0036#d1ec0036a002a14227b0b09117f0dc6182ae19e4"
 dependencies = [
  "soroban-wasmi_core",
  "spin 0.9.4",
@@ -2075,8 +2020,7 @@ dependencies = [
 [[package]]
 name = "soroban-wasmi_core"
 version = "0.16.0-soroban1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468b788f0b3d4080a25243d3f452fb8413c31104bdf7612242b506d1229dfe85"
+source = "git+https://github.com/stellar/wasmi?rev=d1ec0036#d1ec0036a002a14227b0b09117f0dc6182ae19e4"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -2106,8 +2050,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-strkey"
 version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdc24a977b92cac2028693957b8e07ffb9249a0767a548391246c9fb964a439"
+source = "git+https://github.com/stellar/rs-stellar-strkey?rev=5e582a8b#5e582a8b48f85443df60dc78e2e98959862400d6"
 dependencies = [
  "base32",
  "thiserror",
@@ -2125,8 +2068,6 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9295054553418f5d14d9099070acab34e8befab65aae102a3bae79b9cdf76ac0"
 dependencies = [
  "base64",
  "hex",
@@ -2221,14 +2162,14 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 name = "test_hello_world"
 version = "0.2.1"
 dependencies = [
- "soroban-sdk 0.2.1 (git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0)",
+ "soroban-sdk",
 ]
 
 [[package]]
 name = "test_invoker_account_exists"
 version = "0.2.1"
 dependencies = [
- "soroban-sdk 0.2.1 (git+https://github.com/stellar/rs-soroban-sdk?rev=4d2559c0)",
+ "soroban-sdk",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ default-members = ["."]
 version = "0.0.9"
 git = "https://github.com/stellar/rs-soroban-env"
 rev = "c04c2332"
-#path = "../rs-soroban-env/soroban-env-host"
 
 [workspace.dependencies.soroban-spec]
 version = "0.2.1"
@@ -82,6 +81,15 @@ rev = "4d2559c0"
 version = "0.0.6"
 git = "https://github.com/stellar/rs-stellar-strkey"
 rev = "d1b68fd1"
+
+# [patch."https://github.com/stellar/rs-stellar-xdr"]
+# stellar-xdr = { path = "../rs-stellar-xdr/" }
+# [patch."https://github.com/stellar/rs-soroban-env"]
+# soroban-env-host = { path = "../rs-soroban-env/soroban-env-host/" }
+# [patch."https://github.com/stellar/rs-soroban-sdk"]
+# soroban-spec = { path = "../rs-soroban-sdk/soroban-spec/" }
+# soroban-token-spec = { path = "../rs-soroban-sdk/soroban-token-spec/" }
+# soroban-sdk = { path = "../rs-soroban-sdk/soroban-sdk/" }
 
 [profile.test-wasms]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,22 +60,22 @@ default-members = ["."]
 [workspace.dependencies.soroban-env-host]
 version = "0.0.9"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "c04c2332"
+rev = "99de1bf0"
 
 [workspace.dependencies.soroban-spec]
 version = "0.2.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "4d2559c0"
+rev = "63bef69c"
 
 [workspace.dependencies.soroban-token-spec]
 version = "0.2.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "4d2559c0"
+rev = "63bef69c"
 
 [workspace.dependencies.soroban-sdk]
 version = "0.2.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "4d2559c0"
+rev = "63bef69c"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,14 +82,14 @@ version = "0.0.6"
 git = "https://github.com/stellar/rs-stellar-strkey"
 rev = "d1b68fd1"
 
-# [patch."https://github.com/stellar/rs-stellar-xdr"]
-# stellar-xdr = { path = "../rs-stellar-xdr/" }
 # [patch."https://github.com/stellar/rs-soroban-env"]
 # soroban-env-host = { path = "../rs-soroban-env/soroban-env-host/" }
 # [patch."https://github.com/stellar/rs-soroban-sdk"]
 # soroban-spec = { path = "../rs-soroban-sdk/soroban-spec/" }
 # soroban-token-spec = { path = "../rs-soroban-sdk/soroban-token-spec/" }
 # soroban-sdk = { path = "../rs-soroban-sdk/soroban-sdk/" }
+# [patch."https://github.com/stellar/rs-stellar-xdr"]
+# stellar-xdr = { path = "../rs-stellar-xdr/" }
 
 [profile.test-wasms]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ path = "src/main.rs"
 soroban-env-host = { workspace = true, features = ["vm", "serde", "hostfn_log_fmt_values"] }
 soroban-spec = { workspace = true }
 soroban-token-spec = { workspace = true }
-soroban-auth = { workspace = true }
 stellar-strkey = { workspace = true }
 clap = { version = "3.1.18", features = ["derive", "env"] }
 base64 = "0.13.0"
@@ -70,11 +69,6 @@ git = "https://github.com/stellar/rs-soroban-sdk"
 rev = "4d2559c0"
 
 [workspace.dependencies.soroban-token-spec]
-version = "0.2.1"
-git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "4d2559c0"
-
-[workspace.dependencies.soroban-auth]
 version = "0.2.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
 rev = "4d2559c0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,33 +58,36 @@ members = [
 ]
 default-members = ["."]
 
-[workspace.dependencies]
-soroban-env-host = "0.0.9"
-soroban-spec = "0.2.1"
-soroban-token-spec = "0.2.1"
-soroban-auth = "0.2.1"
-stellar-strkey = "0.0.6"
-soroban-sdk = "0.2.1"
+[workspace.dependencies.soroban-env-host]
+version = "0.0.9"
+git = "https://github.com/stellar/rs-soroban-env"
+rev = "c04c2332"
+#path = "../rs-soroban-env/soroban-env-host"
 
-[patch.crates-io]
-soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d2559c0" }
-soroban-token-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d2559c0" }
-soroban-auth = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d2559c0" }
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d2559c0" }
-soroban-sdk-macros = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d2559c0" }
-stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "d1b68fd1" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "e88f9fa7" }
-wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "d1ec0036" }
+[workspace.dependencies.soroban-spec]
+version = "0.2.1"
+git = "https://github.com/stellar/rs-soroban-sdk"
+rev = "4d2559c0"
 
-# soroban-env-common = { path = "../rs-soroban-env/soroban-env-common" }
-# soroban-env-host = { path = "../rs-soroban-env/soroban-env-host" }
-# soroban-env-macros = { path = "../rs-soroban-env/soroban-env-macros" }
-# soroban-native-sdk-macros = { path = "../rs-soroban-env/soroban-native-sdk-macros" }
+[workspace.dependencies.soroban-token-spec]
+version = "0.2.1"
+git = "https://github.com/stellar/rs-soroban-sdk"
+rev = "4d2559c0"
+
+[workspace.dependencies.soroban-auth]
+version = "0.2.1"
+git = "https://github.com/stellar/rs-soroban-sdk"
+rev = "4d2559c0"
+
+[workspace.dependencies.soroban-sdk]
+version = "0.2.1"
+git = "https://github.com/stellar/rs-soroban-sdk"
+rev = "4d2559c0"
+
+[workspace.dependencies.stellar-strkey]
+version = "0.0.6"
+git = "https://github.com/stellar/rs-stellar-strkey"
+rev = "d1b68fd1"
 
 [profile.test-wasms]
 inherits = "release"


### PR DESCRIPTION
### What
Switch to specifying development versions on dependencies instead of separately as patches.

### Why
See https://github.com/stellar/rs-soroban-env/pull/568.
Close https://github.com/stellar/rs-soroban-env/issues/567