### PR TITLE
Make builds and tests consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,36 +24,28 @@ ifeq ($(shell uname -s),Darwin)
 	MACOS_MIN_VER = -ldflags='-extldflags -mmacosx-version-min=13.0'
 endif
 
-# update the Cargo.lock every time the Cargo.toml changes.
-Cargo.lock: Cargo.toml
-	cargo update --workspace
-
-install_rust: Cargo.lock
-	cargo install --path ./cmd/soroban-cli --debug
-	cargo install --path ./cmd/crates/soroban-test/tests/fixtures/hello --root ./target --debug --quiet
-
-install: install_rust
-
-build_rust: Cargo.lock
-	cargo build
+install:
+	cargo install --locked --path ./cmd/soroban-cli --debug
+	cargo install --locked --path ./cmd/crates/soroban-test/tests/fixtures/hello --root ./target --debug --quiet
 
 # regenerate the example lib in `cmd/crates/soroban-spec-typsecript/fixtures/ts`
 build-snapshot: typescript-bindings-fixtures
 
-build: build_rust
+build:
+	cargo build
 
-build-test-wasms: Cargo.lock
+build-test-wasms:
 	cargo build --package 'test_*' --profile test-wasms --target wasm32-unknown-unknown
 
-build-test: build-test-wasms install_rust
+build-test: build-test-wasms install
 
 test: build-test
-	cargo test 
+	cargo test
 
 e2e-test:
 	cargo test --test it -- --ignored
 
-check: Cargo.lock
+check:
 	cargo clippy --all-targets
 
 watch:

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ ifeq ($(shell uname -s),Darwin)
 	MACOS_MIN_VER = -ldflags='-extldflags -mmacosx-version-min=13.0'
 endif
 
+install_rust: install
+
 install:
 	cargo install --locked --path ./cmd/soroban-cli --debug
 	cargo install --locked --path ./cmd/crates/soroban-test/tests/fixtures/hello --root ./target --debug --quiet

--- a/cmd/soroban-cli/src/commands/contract/optimize.rs
+++ b/cmd/soroban-cli/src/commands/contract/optimize.rs
@@ -23,7 +23,7 @@ pub enum Error {
     #[error("optimization error: {0}")]
     OptimizationError(OptimizationError),
     #[cfg(not(feature = "opt"))]
-    #[error("Must install with \"opt\" feature, e.g. `cargo install soroban-cli --features opt")]
+    #[error("Must install with \"opt\" feature, e.g. `cargo install --locked soroban-cli --features opt")]
     Install,
 }
 


### PR DESCRIPTION
### What
Change the install make target to use the lock file, by adding --locked to all cargo install commands. Also encourage --locked usage elsewhere in CLI help output, and fix old make targets that are no longer needed since the split.

### Why
Cargo install won't use the Cargo.lock file at all unless the --locked option is passed. This means that installs in CI are pulling in whatever the latest versions of software that match the Cargo.toml specification. This allows any developer of any dependency to have control over what runs in CI, or on developer machines. It is the main reason to rely on the Cargo.lock file and only update the lock file intentionally.

Cargo build automatically uses the lock file and only modifies it if it needs modifying. Install is one command that unfortunately doesn't use the lock file at all.

Recently the fact that the lock file wasn't in use caused CI to break:
- #1217 