### PR TITLE
Fix option --is-view env var

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -43,7 +43,7 @@ pub struct Cmd {
     #[arg(skip)]
     pub wasm: Option<std::path::PathBuf>,
     /// Do not sign and submit transaction
-    #[arg(long, env = "SOROBAN_INVOKE_SIGN", env = "SYSTEM_TEST_VERBOSE_OUTPUT")]
+    #[arg(long, env = "SOROBAN_INVOKE_VIEW")]
     pub is_view: bool,
     /// Function name as subcommand, then arguments for that function as `--arg-name value`
     #[arg(last = true, id = "CONTRACT_FN_AND_ARGS")]

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -150,7 +150,9 @@ impl From<Infallible> for Error {
 impl Cmd {
     fn is_view(&self) -> bool {
         self.is_view ||
-            // TODO: Remove at next major release. Was added 
+            // TODO: Remove at next major release. Was added to retain backwards
+            // compatibility when this env var used to be used for the --is-view
+            // option.
             std::env::var("SYSTEM_TEST_VERBOSE_OUTPUT").as_deref() == Ok("true")
     }
 
@@ -256,7 +258,7 @@ impl Cmd {
     }
 
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
-        let res = self.invoke(global_args).await?;
+        let res = selVjf.invoke(global_args).await?;
         println!("{res}");
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -258,7 +258,7 @@ impl Cmd {
     }
 
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
-        let res = selVjf.invoke(global_args).await?;
+        let res = self.invoke(global_args).await?;
         println!("{res}");
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -42,7 +42,7 @@ pub struct Cmd {
     // For testing only
     #[arg(skip)]
     pub wasm: Option<std::path::PathBuf>,
-    /// Do not sign and submit transaction
+    /// View the result simulating and do not sign and submit transaction
     #[arg(long, env = "SOROBAN_INVOKE_VIEW")]
     pub is_view: bool,
     /// Function name as subcommand, then arguments for that function as `--arg-name value`

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -45,8 +45,6 @@ pub struct Cmd {
     /// View the result simulating and do not sign and submit transaction
     #[arg(long, env = "SOROBAN_INVOKE_VIEW")]
     pub is_view: bool,
-    #[arg(long, env = "SYSTEM_TEST_VERBOSE_OUTPUT", hide = true)]
-    pub is_view_deprecated: bool,
     /// Function name as subcommand, then arguments for that function as `--arg-name value`
     #[arg(last = true, id = "CONTRACT_FN_AND_ARGS")]
     pub slop: Vec<OsString>,
@@ -151,7 +149,9 @@ impl From<Infallible> for Error {
 
 impl Cmd {
     fn is_view(&self) -> bool {
-        self.is_view || self.is_view_deprecated
+        self.is_view ||
+            // TODO: Remove at next major release. Was added 
+            std::env::var("SYSTEM_TEST_VERBOSE_OUTPUT").as_deref() == Ok("true")
     }
 
     fn build_host_function_parameters(

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -953,7 +953,7 @@ soroban contract invoke ... -- --help
 ###### **Options:**
 
 * `--id <CONTRACT_ID>` — Contract ID to invoke
-* `--is-view` — Do not sign and submit transaction
+* `--is-view` — View the result simulating and do not sign and submit transaction
 
   Possible values: `true`, `false`
 


### PR DESCRIPTION
### What
Change the cli --is-view env var to be `SOROBAN_INVOKE_VIEW` instead of `SYSTEM_TEST_VERBOSE_OUTPUT`, retaining support for the previous env var for backwards compatibility.

### Why
In #1194 when the env var was added it appears we accidentally named it a name that doesn't have anything to do with the option. The env var is actually the name of an env var used in the system test suite, so I'm going to guess that a find all and rename went awry and maybe renamed an env var here that shouldn't have been.

At the moment two env vars are attached to the option, and only the second one appears to be useable in my testing, as the second env parameter overrides the first.

This change is not a breaking change and can be released in a patch release as a bug fix.

The old env var is not advertised in the help output.

### Example

#### Before

```
      --is-view
          Do not sign and submit transaction
          
          [env: SYSTEM_TEST_VERBOSE_OUTPUT=]
```

#### After

```
      --is-view
          View the result simulating and do not sign and submit transaction
          
          [env: SOROBAN_INVOKE_VIEW=]
```