### PR TITLE
docs: update URLs displayed in the "about" command

### DIFF
--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -17,8 +17,8 @@ pub mod version;
 pub const HEADING_RPC: &str = "Options (RPC)";
 const ABOUT: &str = "Build, deploy, & interact with contracts; set identities to sign with; configure networks; generate keys; and more.
 
-Intro: https://soroban.stellar.org
-CLI Reference: https://github.com/stellar/soroban-tools/tree/main/docs/soroban-cli-full-docs.md";
+Intro: https://soroban.stellar.org/docs
+CLI Reference: https://github.com/stellar/soroban-cli/tree/main/docs/soroban-cli-full-docs.md";
 
 // long_about is shown when someone uses `--help`; short help when using `-h`
 const LONG_ABOUT: &str = "

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -75,8 +75,8 @@ This document contains the help content for the `soroban` command-line program.
 
 Build, deploy, & interact with contracts; set identities to sign with; configure networks; generate keys; and more.
 
-Intro: https://soroban.stellar.org
-CLI Reference: https://github.com/stellar/soroban-tools/tree/main/docs/soroban-cli-full-docs.md
+Intro: https://soroban.stellar.org/docs
+CLI Reference: https://github.com/stellar/soroban-cli/tree/main/docs/soroban-cli-full-docs.md
 
 The easiest way to get started is to generate a new identity:
 


### PR DESCRIPTION
I noticed when running `soroban` or `soroban --help` the github repo link was still pointing to `stellar/soroban-tools`. So, I changed that, and I added the `/docs` path to the `soroban.stellar.org` URL while I was at it (since there's no landing page at the `/` root path)