### PR TITLE
fix: #1251

### DIFF
--- a/cmd/soroban-cli/src/commands/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/network/mod.rs
@@ -172,7 +172,6 @@ impl Network {
         if self.network_passphrase.as_str() == LOCAL_NETWORK_PASSPHRASE {
             let auth = rpc_uri.authority().unwrap().clone();
             let scheme = rpc_uri.scheme_str().unwrap();
-            // format!("{scheme}://{auth}/friendbot");
             Ok(Uri::builder()
                 .authority(auth)
                 .scheme(scheme)
@@ -181,7 +180,7 @@ impl Network {
         } else {
             let client = Client::new(&self.rpc_url)?;
             let uri = client.friendbot_url().await?;
-            Uri::from_str(&format!("{uri:?}?addr={addr}")).map_err(|e| {
+            Uri::from_str(&format!("{uri}?addr={addr}")).map_err(|e| {
                 tracing::error!("{e}");
                 Error::InvalidUrl(uri.to_string())
             })


### PR DESCRIPTION
This fixes a issue caused by quotes around the friendbot url caused by using Debug `{uri:?} instead of Display `{uri}`.