### PR TITLE
Do not raise error when trying to fund account on windows.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,8 @@ jobs:
         - os: windows-latest-8-cores
           target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
+    env:
+      CI_TESTS: true
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main

--- a/cmd/crates/soroban-test/tests/it/config.rs
+++ b/cmd/crates/soroban-test/tests/it/config.rs
@@ -183,6 +183,40 @@ fn generate_key() {
 }
 
 #[test]
+fn generate_key_on_testnet() {
+    if std::env::var("CI_TEST").is_err() {
+        return;
+    }
+    let sandbox = TestEnv::default();
+    sandbox
+        .new_assert_cmd("keys")
+        .arg("generate")
+        .arg("--rpc-url=https://soroban-testnet.stellar.org:443")
+        .arg("--network-passphrase=Test SDF Network ; September 2015")
+        .arg("test_2")
+        .assert()
+        .stdout("")
+        .stderr("")
+        .success();
+
+    sandbox
+        .new_assert_cmd("keys")
+        .arg("ls")
+        .assert()
+        .stdout(predicates::str::contains("test_2\n"));
+    println!(
+        "aa {}",
+        sandbox
+            .new_assert_cmd("keys")
+            .arg("address")
+            .arg("test_2")
+            .assert()
+            .success()
+            .stdout_as_str()
+    );
+}
+
+#[test]
 fn seed_phrase() {
     let sandbox = TestEnv::default();
     let dir = sandbox.dir();

--- a/cmd/soroban-cli/src/commands/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/network/mod.rs
@@ -194,18 +194,11 @@ impl Network {
         let response = match uri.scheme_str() {
             Some("http") => hyper::Client::new().get(uri.clone()).await?,
             Some("https") => {
-                #[cfg(target_os = "windows")]
-                {
-                    return Err(Error::WindowsNotSupported(uri.to_string()));
-                }
-                #[cfg(not(target_os = "windows"))]
-                {
-                    let https = hyper_tls::HttpsConnector::new();
-                    hyper::Client::builder()
-                        .build::<_, hyper::Body>(https)
-                        .get(uri.clone())
-                        .await?
-                }
+                let https = hyper_tls::HttpsConnector::new();
+                hyper::Client::builder()
+                    .build::<_, hyper::Body>(https)
+                    .get(uri.clone())
+                    .await?
             }
             _ => {
                 return Err(Error::InvalidUrl(uri.to_string()));


### PR DESCRIPTION
### What

Remove exception when trying to run `soroban keys generate` on windows.

![soroban-keys-generate-windows](https://github.com/stellar/soroban-cli/assets/3009/e3ddcfb4-37a0-4f96-88ec-fcc027334222)

### Why

So we can properly fund testnet accounts on Windows.

### Known limitations

N/A
