### PR TITLE
fix/remove unecessary fields from template Cargo.toml

### DIFF
--- a/cmd/soroban-cli/src/utils/contract-init-template/contracts/hello_world/Cargo.toml.removeextension
+++ b/cmd/soroban-cli/src/utils/contract-init-template/contracts/hello_world/Cargo.toml.removeextension
@@ -1,11 +1,7 @@
 [package]
 name = "soroban-hello-world-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
-publish = false
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
### What

Remove unnecessary fields from init template Cargo.toml file, based on [this convo](https://aha-labs.slack.com/archives/C04B02ABF37/p1710446000502889?thread_ts=1710445851.799869&cid=C04B02ABF37) on slack.

These files were proposed to be omitted/updated:

- [x] authors omitted
- [x] license omitted
- [x] rust-version omitted
- [x] publish omitted
- [ ] name be changed to the name of the package vs `soroban-hello-world-contract`


