### PR TITLE
feat: add no-build option for fee::Args

### DIFF
--- a/cmd/crates/soroban-spec-tools/src/lib.rs
+++ b/cmd/crates/soroban-spec-tools/src/lib.rs
@@ -1137,8 +1137,7 @@ impl Spec {
                     ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 { fields, .. })
                         if fields
                             .first()
-                            .map(|f| f.name.to_utf8_string_lossy() == "0")
-                            .unwrap_or_default() =>
+                            .is_some_and(|f| f.name.to_utf8_string_lossy() == "0") =>
                     {
                         let fields = fields
                             .iter()

--- a/cmd/crates/soroban-test/src/lib.rs
+++ b/cmd/crates/soroban-test/src/lib.rs
@@ -236,22 +236,25 @@ impl TestEnv {
             },
             hd_path: None,
         };
-        cmd.run_against_rpc_server(
-            Some(&global::Args {
-                locator: config::locator::Args {
-                    global: false,
-                    config_dir,
-                },
-                filter_logs: Vec::default(),
-                quiet: false,
-                verbose: false,
-                very_verbose: false,
-                list: false,
-                no_cache: false,
-            }),
-            Some(&config),
-        )
-        .await
+        Ok(cmd
+            .run_against_rpc_server(
+                Some(&global::Args {
+                    locator: config::locator::Args {
+                        global: false,
+                        config_dir,
+                    },
+                    filter_logs: Vec::default(),
+                    quiet: false,
+                    verbose: false,
+                    very_verbose: false,
+                    list: false,
+                    no_cache: false,
+                }),
+                Some(&config),
+            )
+            .await?
+            .res()
+            .unwrap())
     }
 
     /// Reference to current directory of the `TestEnv`.

--- a/cmd/crates/soroban-test/src/lib.rs
+++ b/cmd/crates/soroban-test/src/lib.rs
@@ -193,7 +193,9 @@ impl TestEnv {
         source: &str,
     ) -> Result<String, invoke::Error> {
         let cmd = self.cmd_with_config::<I, invoke::Cmd>(command_str);
-        self.run_cmd_with(cmd, source).await
+        self.run_cmd_with(cmd, source)
+            .await
+            .map(|r| r.into_result().unwrap())
     }
 
     /// A convenience method for using the invoke command.
@@ -236,25 +238,22 @@ impl TestEnv {
             },
             hd_path: None,
         };
-        Ok(cmd
-            .run_against_rpc_server(
-                Some(&global::Args {
-                    locator: config::locator::Args {
-                        global: false,
-                        config_dir,
-                    },
-                    filter_logs: Vec::default(),
-                    quiet: false,
-                    verbose: false,
-                    very_verbose: false,
-                    list: false,
-                    no_cache: false,
-                }),
-                Some(&config),
-            )
-            .await?
-            .into_res()
-            .unwrap())
+        cmd.run_against_rpc_server(
+            Some(&global::Args {
+                locator: config::locator::Args {
+                    global: false,
+                    config_dir,
+                },
+                filter_logs: Vec::default(),
+                quiet: false,
+                verbose: false,
+                very_verbose: false,
+                list: false,
+                no_cache: false,
+            }),
+            Some(&config),
+        )
+        .await
     }
 
     /// Reference to current directory of the `TestEnv`.

--- a/cmd/crates/soroban-test/src/lib.rs
+++ b/cmd/crates/soroban-test/src/lib.rs
@@ -253,7 +253,7 @@ impl TestEnv {
                 Some(&config),
             )
             .await?
-            .res()
+            .into_res()
             .unwrap())
     }
 

--- a/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
@@ -2,6 +2,7 @@ use predicates::boolean::PredicateBooleanExt;
 use soroban_cli::commands::{
     config::{locator, secret},
     contract::{self, fetch},
+    txn_result::TxnResult,
 };
 use soroban_rpc::GetLatestLedgerResponse;
 use soroban_test::{AssertExt, TestEnv, LOCAL_NETWORK_PASSPHRASE};
@@ -20,7 +21,7 @@ async fn invoke_view_with_non_existent_source_account() {
     cmd.config.source_account = String::new();
     cmd.is_view = true;
     let res = sandbox.run_cmd_with(cmd, "test").await.unwrap();
-    assert_eq!(res, format!(r#"["Hello",{world:?}]"#));
+    assert_eq!(res, TxnResult::Res(format!(r#"["Hello",{world:?}]"#)));
 }
 
 #[tokio::test]
@@ -163,7 +164,7 @@ fn hello_world_cmd(id: &str, arg: &str) -> contract::invoke::Cmd {
 async fn invoke_hello_world_with_lib(e: &TestEnv, id: &str) {
     let cmd = hello_world_cmd(id, "world");
     let res = e.run_cmd_with(cmd, "test").await.unwrap();
-    assert_eq!(res, r#"["Hello","world"]"#);
+    assert_eq!(res, TxnResult::Res(r#"["Hello","world"]"#.to_string()));
 }
 
 fn invoke_auth(sandbox: &TestEnv, id: &str, addr: &str) {

--- a/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
@@ -12,6 +12,18 @@ use super::util::{deploy_hello, extend, HELLO_WORLD};
 
 #[allow(clippy::too_many_lines)]
 #[tokio::test]
+async fn invoke_view_with_non_existent_source_account() {
+    let sandbox = &TestEnv::new();
+    let id = deploy_hello(sandbox).await;
+    let world = "world";
+    let mut cmd = hello_world_cmd(&id, world);
+    cmd.config.source_account = String::new();
+    cmd.is_view = true;
+    let res = sandbox.run_cmd_with(cmd, "test").await.unwrap();
+    assert_eq!(res, format!(r#"["Hello",{world:?}]"#));
+}
+
+#[tokio::test]
 async fn invoke() {
     let sandbox = &TestEnv::new();
     let c = soroban_rpc::Client::new(&sandbox.rpc_url).unwrap();
@@ -140,12 +152,16 @@ fn invoke_hello_world(sandbox: &TestEnv, id: &str) {
         .success();
 }
 
-async fn invoke_hello_world_with_lib(e: &TestEnv, id: &str) {
-    let cmd = contract::invoke::Cmd {
+fn hello_world_cmd(id: &str, arg: &str) -> contract::invoke::Cmd {
+    contract::invoke::Cmd {
         contract_id: id.to_string(),
-        slop: vec!["hello".into(), "--world=world".into()],
+        slop: vec!["hello".into(), format!("--world={arg}").into()],
         ..Default::default()
-    };
+    }
+}
+
+async fn invoke_hello_world_with_lib(e: &TestEnv, id: &str) {
+    let cmd = hello_world_cmd(id, "world");
     let res = e.run_cmd_with(cmd, "test").await.unwrap();
     assert_eq!(res, r#"["Hello","world"]"#);
 }

--- a/cmd/crates/soroban-test/tests/it/integration/util.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/util.rs
@@ -38,7 +38,12 @@ pub async fn deploy_contract(sandbox: &TestEnv, wasm: &Wasm<'static>) -> String 
         TEST_SALT,
         "--ignore-checks",
     ]);
-    sandbox.run_cmd_with(cmd, "test").await.unwrap()
+    sandbox
+        .run_cmd_with(cmd, "test")
+        .await
+        .unwrap()
+        .into_result()
+        .unwrap()
 }
 
 pub async fn extend_contract(sandbox: &TestEnv, id: &str) {

--- a/cmd/crates/soroban-test/tests/it/util.rs
+++ b/cmd/crates/soroban-test/tests/it/util.rs
@@ -53,7 +53,10 @@ pub async fn invoke_custom(
 ) -> Result<String, contract::invoke::Error> {
     let mut i: contract::invoke::Cmd = sandbox.cmd_with_config(&["--id", id, "--", func, arg]);
     i.wasm = Some(wasm.to_path_buf());
-    sandbox.run_cmd_with(i, TEST_ACCOUNT).await
+    sandbox
+        .run_cmd_with(i, TEST_ACCOUNT)
+        .await
+        .map(|r| r.into_result().unwrap())
 }
 
 pub const DEFAULT_CONTRACT_ID: &str = "CDR6QKTWZQYW6YUJ7UP7XXZRLWQPFRV6SWBLQS4ZQOSAF4BOUD77OO5Z";

--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -14,7 +14,9 @@ use std::{array::TryFromSliceError, fmt::Debug, num::ParseIntError};
 use crate::{
     commands::{
         config::{self, data},
-        global, network, NetworkRunnable,
+        global, network,
+        txn_result::TxnResult,
+        NetworkRunnable,
     },
     rpc::{Client, Error as SorobanRpcError},
     utils::{contract_id_hash_from_asset, parsing::parse_asset},
@@ -80,7 +82,7 @@ impl NetworkRunnable for Cmd {
         &self,
         args: Option<&global::Args>,
         config: Option<&config::Args>,
-    ) -> Result<String, Error> {
+    ) -> Result<TxnResult<String>, Error> {
         let config = config.unwrap_or(&self.config);
         // Parse asset
         let asset = parse_asset(&self.asset)?;
@@ -108,8 +110,11 @@ impl NetworkRunnable for Cmd {
             network_passphrase,
             &key,
         )?;
+        if self.fee.build_only {
+            return Ok(TxnResult::from_xdr(&tx)?);
+        }
         let txn = client.create_assembled_transaction(&tx).await?;
-        let txn = self.fee.apply_to_assembled_txn(txn);
+        let txn = self.fee.apply_to_assembled_txn(txn)?;
         let get_txn_resp = client
             .send_assembled_transaction(txn, &key, &[], network_passphrase, None, None)
             .await?
@@ -118,7 +123,9 @@ impl NetworkRunnable for Cmd {
             data::write(get_txn_resp, &network.rpc_uri()?)?;
         }
 
-        Ok(stellar_strkey::Contract(contract_id.0).to_string())
+        Ok(TxnResult::Xdr(
+            stellar_strkey::Contract(contract_id.0).to_string(),
+        ))
     }
 }
 

--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -114,11 +114,10 @@ impl NetworkRunnable for Cmd {
             return Ok(TxnResult::Txn(tx));
         }
         let txn = client.create_assembled_transaction(&tx).await?;
-        let txn = self.fee.apply_to_assembled_txn(txn)?;
-        let txn = match txn {
-            TxnResult::Txn(raw) => return Ok(TxnResult::Txn(raw)),
-            TxnResult::Res(txn) => txn,
-        };
+        let txn = self.fee.apply_to_assembled_txn(txn);
+        if self.fee.sim_only {
+            return Ok(TxnResult::Txn(txn.transaction().clone()));
+        }
         let get_txn_resp = client
             .send_assembled_transaction(txn, &key, &[], network_passphrase, None, None)
             .await?

--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -184,11 +184,10 @@ impl NetworkRunnable for Cmd {
         }
 
         let txn = client.create_assembled_transaction(&txn).await?;
-        let txn = self.fee.apply_to_assembled_txn(txn)?;
-        let txn = match txn {
-            TxnResult::Txn(raw) => return Ok(TxnResult::Txn(raw)),
-            TxnResult::Res(txn) => txn,
-        };
+        let txn = self.fee.apply_to_assembled_txn(txn);
+        if self.fee.sim_only {
+            return Ok(TxnResult::Txn(txn.transaction().clone()));
+        }
         let get_txn_resp = client
             .send_assembled_transaction(txn, &key, &[], &network.network_passphrase, None, None)
             .await?

--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -18,7 +18,7 @@ use crate::commands::{
     config::data,
     contract::{self, id::wasm::get_contract_id},
     global, network,
-    txn_result::{self, TxnResult},
+    txn_result::TxnResult,
     NetworkRunnable,
 };
 use crate::{
@@ -95,8 +95,6 @@ pub enum Error {
     #[error(transparent)]
     WasmId(#[from] contract::id::wasm::Error),
     #[error(transparent)]
-    TxnResult(#[from] txn_result::Error),
-    #[error(transparent)]
     Data(#[from] data::Error),
     #[error(transparent)]
     Network(#[from] network::Error),
@@ -115,7 +113,7 @@ impl Cmd {
 #[async_trait::async_trait]
 impl NetworkRunnable for Cmd {
     type Error = Error;
-    type Result = String;
+    type Result = TxnResult<String>;
 
     async fn run_against_rpc_server(
         &self,
@@ -127,17 +125,16 @@ impl NetworkRunnable for Cmd {
             let hash = if self.fee.build_only {
                 wasm::Args { wasm: wasm.clone() }.hash()?
             } else {
-                let mut fee = self.fee.clone();
-                fee.build_only = false;
                 install::Cmd {
                     wasm: wasm::Args { wasm: wasm.clone() },
                     config: config.clone(),
-                    fee,
+                    fee: self.fee.clone(),
                     ignore_checks: self.ignore_checks,
                 }
                 .run_against_rpc_server(global_args, Some(config))
                 .await?
-                .try_into_res()?
+                .into_result()
+                .expect("the value (hash) is expected because it should always be available since build-only is a shared parameter")
             };
             hex::encode(hash)
         } else {
@@ -183,13 +180,13 @@ impl NetworkRunnable for Cmd {
             &key,
         )?;
         if self.fee.build_only {
-            return Ok(TxnResult::from_xdr(&txn)?);
+            return Ok(TxnResult::Txn(txn));
         }
 
         let txn = client.create_assembled_transaction(&txn).await?;
         let txn = self.fee.apply_to_assembled_txn(txn)?;
         let txn = match txn {
-            TxnResult::Xdr(raw) => return Ok(TxnResult::Xdr(raw)),
+            TxnResult::Txn(raw) => return Ok(TxnResult::Txn(raw)),
             TxnResult::Res(txn) => txn,
         };
         let get_txn_resp = client

--- a/cmd/soroban-cli/src/commands/contract/id/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/id/asset.rs
@@ -26,11 +26,14 @@ pub enum Error {
 }
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
+        println!("{}", self.contract_address()?);
+        Ok(())
+    }
+
+    pub fn contract_address(&self) -> Result<stellar_strkey::Contract, Error> {
         let asset = parse_asset(&self.asset)?;
         let network = self.config.get_network()?;
         let contract_id = contract_id_hash_from_asset(&asset, &network.network_passphrase)?;
-        let strkey_contract_id = stellar_strkey::Contract(contract_id.0).to_string();
-        println!("{strkey_contract_id}");
-        Ok(())
+        Ok(stellar_strkey::Contract(contract_id.0))
     }
 }

--- a/cmd/soroban-cli/src/commands/contract/install.rs
+++ b/cmd/soroban-cli/src/commands/contract/install.rs
@@ -162,6 +162,10 @@ impl NetworkRunnable for Cmd {
             .create_assembled_transaction(&tx_without_preflight)
             .await?;
         let txn = self.fee.apply_to_assembled_txn(txn)?;
+        let txn = match txn {
+            TxnResult::Xdr(raw) => return Ok(TxnResult::Xdr(raw)),
+            TxnResult::Res(txn) => txn,
+        };
         let txn_resp = client
             .send_assembled_transaction(txn, &key, &[], &network.network_passphrase, None, None)
             .await?;

--- a/cmd/soroban-cli/src/commands/contract/install.rs
+++ b/cmd/soroban-cli/src/commands/contract/install.rs
@@ -161,11 +161,10 @@ impl NetworkRunnable for Cmd {
         let txn = client
             .create_assembled_transaction(&tx_without_preflight)
             .await?;
-        let txn = self.fee.apply_to_assembled_txn(txn)?;
-        let txn = match txn {
-            TxnResult::Txn(raw) => return Ok(TxnResult::Txn(raw)),
-            TxnResult::Res(txn) => txn,
-        };
+        let txn = self.fee.apply_to_assembled_txn(txn);
+        if self.fee.sim_only {
+            return Ok(TxnResult::Txn(txn.transaction().clone()));
+        }
         let txn_resp = client
             .send_assembled_transaction(txn, &key, &[], &network.network_passphrase, None, None)
             .await?;

--- a/cmd/soroban-cli/src/commands/contract/install.rs
+++ b/cmd/soroban-cli/src/commands/contract/install.rs
@@ -132,28 +132,33 @@ impl NetworkRunnable for Cmd {
         if self.fee.build_only {
             return Ok(TxnResult::Txn(tx_without_preflight));
         }
-        let code_key =
-            xdr::LedgerKey::ContractCode(xdr::LedgerKeyContractCode { hash: hash.clone() });
-        let contract_data = client.get_ledger_entries(&[code_key]).await?;
-        // Skip install if the contract is already installed, and the contract has an extension version that isn't V0.
-        // In protocol 21 extension V1 was added that stores additional information about a contract making execution
-        // of the contract cheaper. So if folks want to reinstall we should let them which is why the install will still
-        // go ahead if the contract has a V0 extension.
-        if let Some(entries) = contract_data.entries {
-            if let Some(entry_result) = entries.first() {
-                let entry: LedgerEntryData =
-                    LedgerEntryData::from_xdr_base64(&entry_result.xdr, Limits::none())?;
+        // Don't check whether the contract is already installed when the user
+        // has requested to perform simulation only and is hoping to get a
+        // transaction back.
+        if !self.fee.sim_only {
+            let code_key =
+                xdr::LedgerKey::ContractCode(xdr::LedgerKeyContractCode { hash: hash.clone() });
+            let contract_data = client.get_ledger_entries(&[code_key]).await?;
+            // Skip install if the contract is already installed, and the contract has an extension version that isn't V0.
+            // In protocol 21 extension V1 was added that stores additional information about a contract making execution
+            // of the contract cheaper. So if folks want to reinstall we should let them which is why the install will still
+            // go ahead if the contract has a V0 extension.
+            if let Some(entries) = contract_data.entries {
+                if let Some(entry_result) = entries.first() {
+                    let entry: LedgerEntryData =
+                        LedgerEntryData::from_xdr_base64(&entry_result.xdr, Limits::none())?;
 
-                match &entry {
-                    LedgerEntryData::ContractCode(code) => {
-                        // Skip reupload if this isn't V0 because V1 extension already
-                        // exists.
-                        if code.ext.ne(&ContractCodeEntryExt::V0) {
-                            return Ok(TxnResult::Res(hash));
+                    match &entry {
+                        LedgerEntryData::ContractCode(code) => {
+                            // Skip reupload if this isn't V0 because V1 extension already
+                            // exists.
+                            if code.ext.ne(&ContractCodeEntryExt::V0) {
+                                return Ok(TxnResult::Res(hash));
+                            }
                         }
-                    }
-                    _ => {
-                        tracing::warn!("Entry retrieved should be of type ContractCode");
+                        _ => {
+                            tracing::warn!("Entry retrieved should be of type ContractCode");
+                        }
                     }
                 }
             }

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -21,7 +21,9 @@ use soroban_env_host::{
     HostError,
 };
 
-use soroban_sdk::xdr::{AccountEntry, AccountEntryExt, AccountId, ContractDataEntry, DiagnosticEvent, Thresholds};
+use soroban_sdk::xdr::{
+    AccountEntry, AccountEntryExt, AccountId, ContractDataEntry, DiagnosticEvent, Thresholds,
+};
 use soroban_spec::read::FromWasmError;
 use stellar_strkey::DecodeError;
 

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -382,11 +382,10 @@ impl NetworkRunnable for Cmd {
             return Ok(TxnResult::Txn(tx));
         }
         let txn = client.create_assembled_transaction(&tx).await?;
-        let txn = self.fee.apply_to_assembled_txn(txn)?;
-        let txn = match txn {
-            TxnResult::Txn(raw) => return Ok(TxnResult::Txn(raw)),
-            TxnResult::Res(txn) => txn,
-        };
+        let txn = self.fee.apply_to_assembled_txn(txn);
+        if self.fee.sim_only {
+            return Ok(TxnResult::Txn(txn.transaction().clone()));
+        }
         let sim_res = txn.sim_response();
         if global_args.map_or(true, |a| !a.no_cache) {
             data::write(sim_res.clone().into(), &network.rpc_uri()?)?;

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -21,7 +21,7 @@ use soroban_env_host::{
     HostError,
 };
 
-use soroban_sdk::xdr::{
+use soroban_env_host::xdr::{
     AccountEntry, AccountEntryExt, AccountId, ContractDataEntry, DiagnosticEvent, Thresholds,
 };
 use soroban_spec::read::FromWasmError;
@@ -308,7 +308,7 @@ impl Cmd {
 #[async_trait::async_trait]
 impl NetworkRunnable for Cmd {
     type Error = Error;
-    type Result = String;
+    type Result = TxnResult<String>;
 
     async fn run_against_rpc_server(
         &self,
@@ -379,12 +379,12 @@ impl NetworkRunnable for Cmd {
             account_id,
         )?;
         if self.fee.build_only {
-            return Ok(TxnResult::from_xdr(&tx)?);
+            return Ok(TxnResult::Txn(tx));
         }
         let txn = client.create_assembled_transaction(&tx).await?;
         let txn = self.fee.apply_to_assembled_txn(txn)?;
         let txn = match txn {
-            TxnResult::Xdr(raw) => return Ok(TxnResult::Xdr(raw)),
+            TxnResult::Txn(raw) => return Ok(TxnResult::Txn(raw)),
             TxnResult::Res(txn) => txn,
         };
         let sim_res = txn.sim_response();

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -12,15 +12,16 @@ use heck::ToKebabCase;
 
 use soroban_env_host::{
     xdr::{
-        self, ContractDataEntry, Error as XdrError, Hash, HostFunction, InvokeContractArgs,
-        InvokeHostFunctionOp, LedgerEntryData, LedgerFootprint, Memo, MuxedAccount, Operation,
-        OperationBody, Preconditions, ScAddress, ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef,
-        ScVal, ScVec, SequenceNumber, SorobanAuthorizationEntry, SorobanResources, Transaction,
+        self, Hash, HostFunction, InvokeContractArgs, InvokeHostFunctionOp, LedgerEntryData,
+        LedgerFootprint, Memo, MuxedAccount, Operation, OperationBody, Preconditions, PublicKey,
+        ScAddress, ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef, ScVal, ScVec, SequenceNumber,
+        SorobanAuthorizationEntry, SorobanResources, String32, StringM, Transaction,
         TransactionExt, Uint256, VecM,
     },
     HostError,
 };
 
+use soroban_sdk::xdr::{AccountEntry, AccountEntryExt, AccountId, ContractDataEntry, DiagnosticEvent, Thresholds};
 use soroban_spec::read::FromWasmError;
 use stellar_strkey::DecodeError;
 
@@ -28,6 +29,7 @@ use super::super::{
     config::{self, locator},
     events,
 };
+use crate::commands::txn_result::TxnResult;
 use crate::commands::NetworkRunnable;
 use crate::{
     commands::{config::data, global, network},
@@ -80,7 +82,7 @@ pub enum Error {
         error: soroban_spec_tools::Error,
     },
     #[error("cannot add contract to ledger entries: {0}")]
-    CannotAddContractToLedgerEntries(XdrError),
+    CannotAddContractToLedgerEntries(xdr::Error),
     #[error(transparent)]
     // TODO: the Display impl of host errors is pretty user-unfriendly
     //       (it just calls Debug). I think we can do better than that
@@ -109,7 +111,7 @@ pub enum Error {
         error: soroban_spec_tools::Error,
     },
     #[error(transparent)]
-    Xdr(#[from] XdrError),
+    Xdr(#[from] xdr::Error),
     #[error("error parsing int: {0}")]
     ParseIntError(#[from] ParseIntError),
     #[error(transparent)]
@@ -169,6 +171,7 @@ impl Cmd {
         &self,
         contract_id: [u8; 32],
         spec_entries: &[ScSpecEntry],
+        config: &config::Args,
     ) -> Result<(String, Spec, InvokeContractArgs, Vec<SigningKey>), Error> {
         let spec = Spec(Some(spec_entries.to_vec()));
         let mut cmd = clap::Command::new(self.contract_id.clone())
@@ -201,7 +204,7 @@ impl Cmd {
                         let cmd = crate::commands::keys::address::Cmd {
                             name: s.clone(),
                             hd_path: Some(0),
-                            locator: self.config.locator.clone(),
+                            locator: config.locator.clone(),
                         };
                         if let Ok(address) = cmd.public_key() {
                             s = address.to_string();
@@ -272,7 +275,7 @@ impl Cmd {
         Ok(())
     }
 
-    pub async fn invoke(&self, global_args: &global::Args) -> Result<String, Error> {
+    pub async fn invoke(&self, global_args: &global::Args) -> Result<TxnResult<String>, Error> {
         self.run_against_rpc_server(Some(global_args), None).await
     }
 
@@ -309,7 +312,7 @@ impl NetworkRunnable for Cmd {
         &self,
         global_args: Option<&global::Args>,
         config: Option<&config::Args>,
-    ) -> Result<String, Error> {
+    ) -> Result<TxnResult<String>, Error> {
         let config = config.unwrap_or(&self.config);
         let network = config.get_network()?;
         tracing::trace!(?network);
@@ -317,19 +320,24 @@ impl NetworkRunnable for Cmd {
         let spec_entries = self.spec_entries()?;
         if let Some(spec_entries) = &spec_entries {
             // For testing wasm arg parsing
-            let _ = self.build_host_function_parameters(contract_id, spec_entries)?;
+            let _ = self.build_host_function_parameters(contract_id, spec_entries, config)?;
         }
         let client = rpc::Client::new(&network.rpc_url)?;
-        client
-            .verify_network_passphrase(Some(&network.network_passphrase))
-            .await?;
-        let key = config.key_pair()?;
+        let account_details = if self.is_view {
+            default_account_entry()
+        } else {
+            client
+                .verify_network_passphrase(Some(&network.network_passphrase))
+                .await?;
+            let key = config.key_pair()?;
 
-        // Get the account sequence number
-        let public_strkey =
-            stellar_strkey::ed25519::PublicKey(key.verifying_key().to_bytes()).to_string();
-        let account_details = client.get_account(&public_strkey).await?;
+            // Get the account sequence number
+            let public_strkey =
+                stellar_strkey::ed25519::PublicKey(key.verifying_key().to_bytes()).to_string();
+            client.get_account(&public_strkey).await?
+        };
         let sequence: i64 = account_details.seq_num.into();
+        let AccountId(PublicKey::PublicKeyTypeEd25519(account_id)) = account_details.account_id;
 
         let r = client.get_contract_data(&contract_id).await?;
         tracing::trace!("{r:?}");
@@ -361,15 +369,18 @@ impl NetworkRunnable for Cmd {
 
         // Get the ledger footprint
         let (function, spec, host_function_params, signers) =
-            self.build_host_function_parameters(contract_id, &spec_entries)?;
+            self.build_host_function_parameters(contract_id, &spec_entries, config)?;
         let tx = build_invoke_contract_tx(
             host_function_params.clone(),
             sequence + 1,
             self.fee.fee,
-            &key,
+            account_id,
         )?;
+        if self.fee.build_only {
+            return Ok(TxnResult::from_xdr(&tx)?);
+        }
         let txn = client.create_assembled_transaction(&tx).await?;
-        let txn = self.fee.apply_to_assembled_txn(txn);
+        let txn = self.fee.apply_to_assembled_txn(txn)?;
         let sim_res = txn.sim_response();
         if global_args.map_or(true, |a| !a.no_cache) {
             data::write(sim_res.clone().into(), &network.rpc_uri()?)?;
@@ -386,7 +397,7 @@ impl NetworkRunnable for Cmd {
             let res = client
                 .send_assembled_transaction(
                     txn,
-                    &key,
+                    &config.key_pair()?,
                     &signers,
                     &network.network_passphrase,
                     Some(log_events),
@@ -404,10 +415,27 @@ impl NetworkRunnable for Cmd {
     }
 }
 
+const DEFAULT_ACCOUNT_ID: AccountId = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0; 32])));
+
+fn default_account_entry() -> AccountEntry {
+    AccountEntry {
+        account_id: DEFAULT_ACCOUNT_ID,
+        balance: 0,
+        seq_num: SequenceNumber(0),
+        num_sub_entries: 0,
+        inflation_dest: None,
+        flags: 0,
+        home_domain: String32::from(unsafe { StringM::<32>::from_str("TEST").unwrap_unchecked() }),
+        thresholds: Thresholds([0; 4]),
+        signers: unsafe { [].try_into().unwrap_unchecked() },
+        ext: AccountEntryExt::V0,
+    }
+}
+
 fn log_events(
     footprint: &LedgerFootprint,
     auth: &[VecM<SorobanAuthorizationEntry>],
-    events: &[xdr::DiagnosticEvent],
+    events: &[DiagnosticEvent],
 ) {
     crate::log::auth(auth);
     crate::log::diagnostic_events(events, tracing::Level::TRACE);
@@ -418,7 +446,11 @@ fn log_resources(resources: &SorobanResources) {
     crate::log::cost(resources);
 }
 
-pub fn output_to_string(spec: &Spec, res: &ScVal, function: &str) -> Result<String, Error> {
+pub fn output_to_string(
+    spec: &Spec,
+    res: &ScVal,
+    function: &str,
+) -> Result<TxnResult<String>, Error> {
     let mut res_str = String::new();
     if let Some(output) = spec.find_function(function)?.outputs.first() {
         res_str = spec
@@ -429,14 +461,14 @@ pub fn output_to_string(spec: &Spec, res: &ScVal, function: &str) -> Result<Stri
             })?
             .to_string();
     }
-    Ok(res_str)
+    Ok(TxnResult::Res(res_str))
 }
 
 fn build_invoke_contract_tx(
     parameters: InvokeContractArgs,
     sequence: i64,
     fee: u32,
-    key: &SigningKey,
+    source_account_id: Uint256,
 ) -> Result<Transaction, Error> {
     let op = Operation {
         source_account: None,
@@ -446,7 +478,7 @@ fn build_invoke_contract_tx(
         }),
     };
     Ok(Transaction {
-        source_account: MuxedAccount::Ed25519(Uint256(key.verifying_key().to_bytes())),
+        source_account: MuxedAccount::Ed25519(source_account_id),
         fee,
         seq_num: SequenceNumber(sequence),
         cond: Preconditions::None,
@@ -506,16 +538,15 @@ fn build_custom_cmd(name: &str, spec: &Spec) -> Result<clap::Command, Error> {
 
         // Set up special-case arg rules
         arg = match type_ {
-            xdr::ScSpecTypeDef::Bool => arg
+            ScSpecTypeDef::Bool => arg
                 .num_args(0..1)
                 .default_missing_value("true")
                 .default_value("false")
                 .num_args(0..=1),
-            xdr::ScSpecTypeDef::Option(_val) => arg.required(false),
-            xdr::ScSpecTypeDef::I256
-            | xdr::ScSpecTypeDef::I128
-            | xdr::ScSpecTypeDef::I64
-            | xdr::ScSpecTypeDef::I32 => arg.allow_hyphen_values(true),
+            ScSpecTypeDef::Option(_val) => arg.required(false),
+            ScSpecTypeDef::I256 | ScSpecTypeDef::I128 | ScSpecTypeDef::I64 | ScSpecTypeDef::I32 => {
+                arg.allow_hyphen_values(true)
+            }
             _ => arg,
         };
 

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -383,6 +383,10 @@ impl NetworkRunnable for Cmd {
         }
         let txn = client.create_assembled_transaction(&tx).await?;
         let txn = self.fee.apply_to_assembled_txn(txn)?;
+        let txn = match txn {
+            TxnResult::Xdr(raw) => return Ok(TxnResult::Xdr(raw)),
+            TxnResult::Res(txn) => txn,
+        };
         let sim_res = txn.sim_response();
         if global_args.map_or(true, |a| !a.no_cache) {
             data::write(sim_res.clone().into(), &network.rpc_uri()?)?;

--- a/cmd/soroban-cli/src/commands/contract/read.rs
+++ b/cmd/soroban-cli/src/commands/contract/read.rs
@@ -7,9 +7,9 @@ use clap::{command, Parser, ValueEnum};
 use soroban_env_host::{
     xdr::{
         ContractDataEntry, Error as XdrError, LedgerEntryData, LedgerKey, LedgerKeyContractData,
-        ScVal, WriteXdr,
+        Limits, ScVal, WriteXdr,
     },
-    HostError, Limits,
+    HostError,
 };
 
 use crate::{

--- a/cmd/soroban-cli/src/commands/contract/read.rs
+++ b/cmd/soroban-cli/src/commands/contract/read.rs
@@ -9,12 +9,11 @@ use soroban_env_host::{
         ContractDataEntry, Error as XdrError, LedgerEntryData, LedgerKey, LedgerKeyContractData,
         ScVal, WriteXdr,
     },
-    HostError,
+    HostError, Limits,
 };
-use soroban_sdk::xdr::Limits;
 
 use crate::{
-    commands::{config, global, txn_result::TxnResult, NetworkRunnable},
+    commands::{config, global, NetworkRunnable},
     key,
     rpc::{self, Client, FullLedgerEntries, FullLedgerEntry},
 };
@@ -91,13 +90,7 @@ pub enum Error {
 
 impl Cmd {
     pub async fn run(&self) -> Result<(), Error> {
-        let entries = match self.run_against_rpc_server(None, None).await? {
-            TxnResult::Res(res) => res,
-            TxnResult::Xdr(xdr) => {
-                println!("{xdr}");
-                return Ok(());
-            }
-        };
+        let entries = self.run_against_rpc_server(None, None).await?;
         self.output_entries(&entries)
     }
 
@@ -184,12 +177,12 @@ impl NetworkRunnable for Cmd {
         &self,
         _: Option<&global::Args>,
         config: Option<&config::Args>,
-    ) -> Result<TxnResult<FullLedgerEntries>, Error> {
+    ) -> Result<FullLedgerEntries, Error> {
         let config = config.unwrap_or(&self.config);
         let network = config.get_network()?;
         tracing::trace!(?network);
         let client = Client::new(&network.rpc_url)?;
         let keys = self.key.parse_keys()?;
-        Ok(TxnResult::Res(client.get_full_ledger_entries(&keys).await?))
+        Ok(client.get_full_ledger_entries(&keys).await?)
     }
 }

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -14,6 +14,8 @@ pub mod network;
 pub mod plugin;
 pub mod version;
 
+pub mod txn_result;
+
 pub const HEADING_RPC: &str = "Options (RPC)";
 const ABOUT: &str = "Build, deploy, & interact with contracts; set identities to sign with; configure networks; generate keys; and more.
 
@@ -168,5 +170,5 @@ pub trait NetworkRunnable {
         &self,
         global_args: Option<&global::Args>,
         config: Option<&config::Args>,
-    ) -> Result<Self::Result, Self::Error>;
+    ) -> Result<txn_result::TxnResult<Self::Result>, Self::Error>;
 }

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -170,5 +170,5 @@ pub trait NetworkRunnable {
         &self,
         global_args: Option<&global::Args>,
         config: Option<&config::Args>,
-    ) -> Result<txn_result::TxnResult<Self::Result>, Self::Error>;
+    ) -> Result<Self::Result, Self::Error>;
 }

--- a/cmd/soroban-cli/src/commands/txn_result.rs
+++ b/cmd/soroban-cli/src/commands/txn_result.rs
@@ -2,6 +2,7 @@ use std::fmt::{Display, Formatter};
 
 use soroban_env_host::xdr::{Limits, Transaction, WriteXdr};
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TxnResult<R> {
     Txn(Transaction),
     Res(R),

--- a/cmd/soroban-cli/src/commands/txn_result.rs
+++ b/cmd/soroban-cli/src/commands/txn_result.rs
@@ -1,69 +1,34 @@
 use std::fmt::{Display, Formatter};
 
-use soroban_sdk::xdr::{self, Limits, WriteXdr};
+use soroban_env_host::xdr::{Limits, Transaction, WriteXdr};
 
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error("Expect xdr string")]
-    XdrStringExpected,
-    #[error("Expect result")]
-    ResultExpected,
+pub enum TxnResult<R> {
+    Txn(Transaction),
+    Res(R),
 }
 
-pub enum TxnResult<T> {
-    Xdr(String),
-    Res(T),
-}
-
-impl<T> TxnResult<T> {
-    pub fn from_xdr(res: &impl WriteXdr) -> Result<Self, xdr::Error> {
-        Ok(TxnResult::Xdr(res.to_xdr_base64(Limits::none())?))
-    }
-
-    pub fn xdr(&self) -> Option<&str> {
-        match self {
-            TxnResult::Xdr(xdr) => Some(xdr),
-            TxnResult::Res(_) => None,
-        }
-    }
-
-    pub fn res(&self) -> Option<&T> {
+impl<R> TxnResult<R> {
+    pub fn into_result(self) -> Option<R> {
         match self {
             TxnResult::Res(res) => Some(res),
-            TxnResult::Xdr(_) => None,
-        }
-    }
-
-    pub fn into_res(self) -> Option<T> {
-        match self {
-            TxnResult::Res(res) => Some(res),
-            TxnResult::Xdr(_) => None,
-        }
-    }
-
-    pub fn try_xdr(&self) -> Result<&str, Error> {
-        self.xdr().ok_or(Error::XdrStringExpected)
-    }
-
-    pub fn try_res(&self) -> Result<&T, Error> {
-        self.res().ok_or(Error::ResultExpected)
-    }
-    pub fn try_into_res(self) -> Result<T, Error> {
-        match self {
-            TxnResult::Res(res) => Ok(res),
-            TxnResult::Xdr(_) => Err(Error::XdrStringExpected),
+            TxnResult::Txn(_) => None,
         }
     }
 }
 
-impl<T> Display for TxnResult<T>
+impl<V> Display for TxnResult<V>
 where
-    T: Display,
+    V: Display,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            TxnResult::Xdr(xdr) => write!(f, "{xdr}"),
-            TxnResult::Res(res) => write!(f, "{res}"),
+            TxnResult::Txn(tx) => write!(
+                f,
+                "{}",
+                tx.to_xdr_base64(Limits::none())
+                    .map_err(|_| std::fmt::Error)?
+            ),
+            TxnResult::Res(value) => write!(f, "{value}"),
         }
     }
 }

--- a/cmd/soroban-cli/src/commands/txn_result.rs
+++ b/cmd/soroban-cli/src/commands/txn_result.rs
@@ -1,0 +1,56 @@
+use std::fmt::{Display, Formatter};
+
+use soroban_sdk::xdr::{self, Limits, WriteXdr};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Expect xdr string")]
+    XdrStringExpected,
+    #[error("Expect result")]
+    ResultExpected,
+}
+
+pub enum TxnResult<T> {
+    Xdr(String),
+    Res(T),
+}
+
+impl<T> TxnResult<T> {
+    pub fn from_xdr(res: &impl WriteXdr) -> Result<Self, xdr::Error> {
+        Ok(TxnResult::Xdr(res.to_xdr_base64(Limits::none())?))
+    }
+
+    pub fn xdr(&self) -> Option<&str> {
+        match self {
+            TxnResult::Xdr(xdr) => Some(xdr),
+            TxnResult::Res(_) => None,
+        }
+    }
+
+    pub fn res(self) -> Option<T> {
+        match self {
+            TxnResult::Res(res) => Some(res),
+            TxnResult::Xdr(_) => None,
+        }
+    }
+
+    pub fn try_xdr(&self) -> Result<&str, Error> {
+        self.xdr().ok_or(Error::XdrStringExpected)
+    }
+
+    pub fn try_res(self) -> Result<T, Error> {
+        self.res().ok_or(Error::ResultExpected)
+    }
+}
+
+impl<T> Display for TxnResult<T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TxnResult::Xdr(xdr) => write!(f, "{xdr}"),
+            TxnResult::Res(res) => write!(f, "{res}"),
+        }
+    }
+}

--- a/cmd/soroban-cli/src/commands/txn_result.rs
+++ b/cmd/soroban-cli/src/commands/txn_result.rs
@@ -27,7 +27,14 @@ impl<T> TxnResult<T> {
         }
     }
 
-    pub fn res(self) -> Option<T> {
+    pub fn res(&self) -> Option<&T> {
+        match self {
+            TxnResult::Res(res) => Some(res),
+            TxnResult::Xdr(_) => None,
+        }
+    }
+
+    pub fn into_res(self) -> Option<T> {
         match self {
             TxnResult::Res(res) => Some(res),
             TxnResult::Xdr(_) => None,
@@ -38,8 +45,14 @@ impl<T> TxnResult<T> {
         self.xdr().ok_or(Error::XdrStringExpected)
     }
 
-    pub fn try_res(self) -> Result<T, Error> {
+    pub fn try_res(&self) -> Result<&T, Error> {
         self.res().ok_or(Error::ResultExpected)
+    }
+    pub fn try_into_res(self) -> Result<T, Error> {
+        match self {
+            TxnResult::Res(res) => Ok(res),
+            TxnResult::Xdr(_) => Err(Error::XdrStringExpected),
+        }
     }
 }
 

--- a/cmd/soroban-cli/src/fee.rs
+++ b/cmd/soroban-cli/src/fee.rs
@@ -36,7 +36,8 @@ impl Args {
             add_padding_to_instructions(txn)
         };
         if self.sim_only {
-            TxnResult::from_xdr(simulated_txn.transaction())
+            // TODO: Move into callers.
+            Ok(TxnResult::Txn(simulated_txn.transaction().clone()))
         } else {
             Ok(TxnResult::Res(simulated_txn))
         }

--- a/cmd/soroban-cli/src/fee.rs
+++ b/cmd/soroban-cli/src/fee.rs
@@ -27,12 +27,11 @@ pub struct Args {
 
 impl Args {
     pub fn apply_to_assembled_txn(&self, txn: Assembled) -> Assembled {
-        let simulated_txn = if let Some(instructions) = self.instructions {
+        if let Some(instructions) = self.instructions {
             txn.set_max_instructions(instructions)
         } else {
             add_padding_to_instructions(txn)
-        };
-        simulated_txn
+        }
     }
 }
 

--- a/cmd/soroban-cli/src/fee.rs
+++ b/cmd/soroban-cli/src/fee.rs
@@ -3,7 +3,7 @@ use clap::arg;
 use soroban_env_host::xdr;
 use soroban_rpc::Assembled;
 
-use crate::commands::{txn_result::TxnResult, HEADING_RPC};
+use crate::commands::HEADING_RPC;
 
 #[derive(Debug, clap::Args, Clone)]
 #[group(skip)]
@@ -26,21 +26,13 @@ pub struct Args {
 }
 
 impl Args {
-    pub fn apply_to_assembled_txn(
-        &self,
-        txn: Assembled,
-    ) -> Result<TxnResult<Assembled>, xdr::Error> {
+    pub fn apply_to_assembled_txn(&self, txn: Assembled) -> Assembled {
         let simulated_txn = if let Some(instructions) = self.instructions {
             txn.set_max_instructions(instructions)
         } else {
             add_padding_to_instructions(txn)
         };
-        if self.sim_only {
-            // TODO: Move into callers.
-            Ok(TxnResult::Txn(simulated_txn.transaction().clone()))
-        } else {
-            Ok(TxnResult::Res(simulated_txn))
-        }
+        simulated_txn
     }
 }
 

--- a/cmd/soroban-cli/src/lib.rs
+++ b/cmd/soroban-cli/src/lib.rs
@@ -3,9 +3,10 @@
     clippy::must_use_candidate,
     clippy::missing_panics_doc
 )]
+use std::path::Path;
+
 pub(crate) use soroban_env_host::xdr;
 pub(crate) use soroban_rpc as rpc;
-use std::path::Path;
 
 pub mod commands;
 pub mod fee;

--- a/cmd/soroban-cli/src/wasm.rs
+++ b/cmd/soroban-cli/src/wasm.rs
@@ -1,5 +1,6 @@
 use clap::arg;
-use soroban_env_host::xdr::{self, LedgerKey, LedgerKeyContractCode};
+use sha2::{Digest, Sha256};
+use soroban_env_host::xdr::{self, Hash, LedgerKey, LedgerKeyContractCode};
 use soroban_spec_tools::contract::{self, Spec};
 use std::{
     fs, io,
@@ -64,6 +65,10 @@ impl Args {
     pub fn parse(&self) -> Result<Spec, Error> {
         let contents = self.read()?;
         Ok(Spec::new(&contents)?)
+    }
+
+    pub fn hash(&self) -> Result<Hash, Error> {
+        Ok(Hash(Sha256::digest(self.read()?).into()))
     }
 }
 

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -240,6 +240,14 @@ Deploy builtin Soroban Asset Contract
   Possible values: `true`, `false`
 
 * `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction only write the base64 xdr to stdout
+
+  Possible values: `true`, `false`
+
+* `--sim-only` — Simulation the transaction only write the base64 xdr to stdout
+
+  Possible values: `true`, `false`
+
 
 
 
@@ -391,6 +399,14 @@ If no keys are specified the contract itself is extended.
   Possible values: `true`, `false`
 
 * `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction only write the base64 xdr to stdout
+
+  Possible values: `true`, `false`
+
+* `--sim-only` — Simulation the transaction only write the base64 xdr to stdout
+
+  Possible values: `true`, `false`
+
 
 
 
@@ -423,6 +439,14 @@ Deploy a wasm contract
   Possible values: `true`, `false`
 
 * `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction only write the base64 xdr to stdout
+
+  Possible values: `true`, `false`
+
+* `--sim-only` — Simulation the transaction only write the base64 xdr to stdout
+
+  Possible values: `true`, `false`
+
 * `-i`, `--ignore-checks` — Whether to ignore safety checks when deploying contracts
 
   Default value: `false`
@@ -587,6 +611,14 @@ Install a WASM file to the ledger without creating a contract instance
   Possible values: `true`, `false`
 
 * `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction only write the base64 xdr to stdout
+
+  Possible values: `true`, `false`
+
+* `--sim-only` — Simulation the transaction only write the base64 xdr to stdout
+
+  Possible values: `true`, `false`
+
 * `--wasm <WASM>` — Path to wasm binary
 * `-i`, `--ignore-checks` — Whether to ignore safety checks when deploying contracts
 
@@ -636,6 +668,14 @@ soroban contract invoke ... -- --help
   Possible values: `true`, `false`
 
 * `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction only write the base64 xdr to stdout
+
+  Possible values: `true`, `false`
+
+* `--sim-only` — Simulation the transaction only write the base64 xdr to stdout
+
+  Possible values: `true`, `false`
+
 
 
 
@@ -748,6 +788,14 @@ If no keys are specificed the contract itself is restored.
   Possible values: `true`, `false`
 
 * `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction only write the base64 xdr to stdout
+
+  Possible values: `true`, `false`
+
+* `--sim-only` — Simulation the transaction only write the base64 xdr to stdout
+
+  Possible values: `true`, `false`
+
 
 
 
@@ -1338,6 +1386,9 @@ Read cached action
 ###### **Options:**
 
 * `--id <ID>` — ID of the cache entry
+
+  Possible values: `envelope`
+
 
 
 

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -1387,9 +1387,6 @@ Read cached action
 
 * `--id <ID>` — ID of the cache entry
 
-  Possible values: `envelope`
-
-
 
 
 <hr/>


### PR DESCRIPTION
Fixes #1265.
Requires: #1173 

Commands that build transactions now include the following args to output and exit early:
- [x] `--build-only` prints the base64 xdr before simulation
- [x] `--sim-only` prints the base64 xdr after simulation

For example,

```
soroban contract invoke --build-only .. -- hello --world world
```
prints:
[`
AAAAAMwWyQMtAWO6nW4s+cKMRunx+kiaKfjJwIRNZEEclDvRAAAAZAAIgAEAAAANAAAAAAAAAAAAAAABAAAAAAAAABgAAAAAAAAAAQ3DO777M8sdGtPbMau+cuxAles4UILfUkZXOWTsqKvOAAAABWhlbGxvAAAAAAAAAQAAAA8AAAAFd29ybGQAAAAAAAAAAAAAAA==
`](https://laboratory.stellar.org/#xdr-viewer?input=AAAAAMwWyQMtAWO6nW4s+cKMRunx+kiaKfjJwIRNZEEclDvRAAAAZAAIgAEAAAANAAAAAAAAAAAAAAABAAAAAAAAABgAAAAAAAAAAQ3DO777M8sdGtPbMau+cuxAles4UILfUkZXOWTsqKvOAAAABWhlbGxvAAAAAAAAAQAAAA8AAAAFd29ybGQAAAAAAAAAAAAAAA==&type=Transaction&network=test)

```
soroban contract invoke --sim-only .. -- hello --world world
```


[`AAAAAMwWyQMtAWO6nW4s%2BcKMRunx%2BkiaKfjJwIRNZEEclDvRAAD4WAAIgAEAAAANAAAAAAAAAAAAAAABAAAAAAAAABgAAAAAAAAAAQ3DO777M8sdGtPbMau%2BcuxAles4UILfUkZXOWTsqKvOAAAABWhlbGxvAAAAAAAAAQAAAA8AAAAFd29ybGQAAAAAAAAAAAAAAQAAAAAAAAACAAAABgAAAAENwzu%2B%2BzPLHRrT2zGrvnLsQJXrOFCC31JGVzlk7KirzgAAABQAAAABAAAAB3mMSQSdZWZNBqeYQchZLRMLUhSFaxsEJAOkX%2Bel%2B%2BMzAAAAAABcQYMAABsoAAAAAAAAAAAAANeQ
`](https://laboratory.stellar.org/#xdr-viewer?input=AAAAAMwWyQMtAWO6nW4s%2BcKMRunx%2BkiaKfjJwIRNZEEclDvRAAD4WAAIgAEAAAANAAAAAAAAAAAAAAABAAAAAAAAABgAAAAAAAAAAQ3DO777M8sdGtPbMau%2BcuxAles4UILfUkZXOWTsqKvOAAAABWhlbGxvAAAAAAAAAQAAAA8AAAAFd29ybGQAAAAAAAAAAAAAAQAAAAAAAAACAAAABgAAAAENwzu%2B%2BzPLHRrT2zGrvnLsQJXrOFCC31JGVzlk7KirzgAAABQAAAABAAAAB3mMSQSdZWZNBqeYQchZLRMLUhSFaxsEJAOkX%2Bel%2B%2BMzAAAAAABcQYMAABsoAAAAAAAAAAAAANeQ&type=Transaction&network=test)

# Transaction result

The NetworkRunable trait a result type of `TxnResult`, either a raw xdr string or a T. This allows returning early.

## update `is-view`
Ensure that `is-view` doesn't fetch account info as a source account doesn't need to exist for a simulation.

