### PR TITLE
Allow for multisig using a custom wallet

### DIFF
--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/src/assembled-tx.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/src/assembled-tx.ts
@@ -287,11 +287,6 @@ export class AssembledTransaction<T> {
       throw new Error(`You must submit the transaction with the account that originally created it. Please switch to the wallet with "${this.raw.source}" as its public key.`)
     }
 
-    if ((await this.needsNonInvokerSigningBy()).length) {
-      throw new NeedsMoreSignaturesError(
-        'Transaction requires more signatures. See `needsNonInvokerSigningBy` for details.'
-      )
-    }
 
     return await SentTransaction.init(this.options, this, secondsToWait);
   }
@@ -408,7 +403,6 @@ export class AssembledTransaction<T> {
     if (!needsNonInvokerSigningBy) throw new NoUnsignedNonInvokerAuthEntriesError('No unsigned non-invoker auth entries; maybe you already signed?')
     const publicKey = await this.getPublicKey()
     if (!publicKey) throw new Error('Could not get public key from wallet; maybe Freighter is not signed in?')
-    if (needsNonInvokerSigningBy.indexOf(publicKey) === -1) throw new Error(`No auth entries for public key "${publicKey}"`)
     const wallet = await this.getWallet()
 
     const rawInvokeHostFunctionOp = this.raw

--- a/cmd/crates/soroban-spec-typescript/src/project_template/src/assembled-tx.ts
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/src/assembled-tx.ts
@@ -287,11 +287,6 @@ export class AssembledTransaction<T> {
       throw new Error(`You must submit the transaction with the account that originally created it. Please switch to the wallet with "${this.raw.source}" as its public key.`)
     }
 
-    if ((await this.needsNonInvokerSigningBy()).length) {
-      throw new NeedsMoreSignaturesError(
-        'Transaction requires more signatures. See `needsNonInvokerSigningBy` for details.'
-      )
-    }
 
     return await SentTransaction.init(this.options, this, secondsToWait);
   }
@@ -408,7 +403,6 @@ export class AssembledTransaction<T> {
     if (!needsNonInvokerSigningBy) throw new NoUnsignedNonInvokerAuthEntriesError('No unsigned non-invoker auth entries; maybe you already signed?')
     const publicKey = await this.getPublicKey()
     if (!publicKey) throw new Error('Could not get public key from wallet; maybe Freighter is not signed in?')
-    if (needsNonInvokerSigningBy.indexOf(publicKey) === -1) throw new Error(`No auth entries for public key "${publicKey}"`)
     const wallet = await this.getWallet()
 
     const rawInvokeHostFunctionOp = this.raw


### PR DESCRIPTION
### What

You can use the Soroban generated bindings to invoke functions that require extra signatures with `require_auth` by doing the following:

In the contract:
```
pub fn buy(e: Env, buyer:Address, mft: String, amount: i128) {
    buyer.require_auth();
    //  extra logic
}
```

Using the generated bindings:
```
const contract = new Contract({
  ...networks.testnet,
  rpcUrl: 'https://soroban-testnet.stellar.org', // from https://soroban.stellar.org/docs/reference/rpc-list#sdf-futurenet-and-testnet-only
  wallet: {
     ...,
    signAuthEntry: async (entryXdr, opts) => {
         return extraKeys.sign(hash(Buffer.from(entryXdr, 'base64'))).toString('base64');
    },
  },
});
```
 
then invoke like this:

```
const tx = await contract.buy({
  buyer: buyerKeys.publicKey(),
  mft: mftHash,
  amount: BigInt(10),
});

await tx.signAuthEntries();
const res = await tx.signAndSend();

```

### Why

Servers that manage multiple keys will need this feature in the future, right now the only way to do it is by passing around the tx and getting it signed with Freighter which is nice. It would be great if we can add support for multiple signatures for testing purposes and other use cases.

Thanks!

Alejo 

