### PR TITLE
fix: depend on a real, deployed RPC version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3951,9 +3951,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-rpc-client"
-version = "20.3.5"
+version = "20.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c98cb5068faa68bb4eae0ddd492752042be3c85df145483669936fd794388e"
+checksum = "11b76b620319d599e7171452bfafc19d92f219beb35c60dea02f895e2603eae9"
 dependencies = [
  "base64 0.21.7",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ path = "cmd/soroban-cli"
 
 [workspace.dependencies.soroban-rpc]
 package = "stellar-rpc-client"
-version = "=20.3.5"
+version = "=20.3.3"
 
 [workspace.dependencies.stellar-xdr]
 version = "=20.1.0"


### PR DESCRIPTION
### What

Roll back RPC dependency

### Why

`main` and the latest released version of the CLI are totally broken
because the 3.3.5 release of the RPC was yanked. While we are waiting
for that yank to be rolled back (it was related to a bug in simulation,
which does not introduce security vulnerabilities and which did not need
to be yanked), rolling back the RPC version _may_ work well enough. I
say "may" because I don't really know if there are other dependencies on
the latest RPC here. Let's see if CI passes, i guess?


### Known limitations

Unknown!