### PR TITLE
Update astro template repo url.

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/init.rs
+++ b/cmd/soroban-cli/src/commands/contract/init.rs
@@ -523,7 +523,7 @@ mod tests {
         let with_examples = vec![];
         init(
             project_dir.as_path(),
-            "https://github.com/AhaLabs/soroban-astro-template",
+            "https://github.com/stellar/soroban-astro-template",
             &with_examples,
         )
         .unwrap();
@@ -551,7 +551,7 @@ mod tests {
         let with_examples = vec![];
         init(
             project_dir.as_path(),
-            "https://github.com/AhaLabs/soroban-astro-template",
+            "https://github.com/stellar/soroban-astro-template",
             &with_examples,
         )
         .unwrap();
@@ -581,7 +581,7 @@ mod tests {
         let with_examples = vec![];
         init(
             project_dir.as_path(),
-            "https://github.com/AhaLabs/soroban-astro-template",
+            "https://github.com/stellar/soroban-astro-template",
             &with_examples,
         )
         .unwrap();
@@ -589,7 +589,7 @@ mod tests {
         // call init again to make sure the README.md's contents are not duplicated
         init(
             project_dir.as_path(),
-            "https://github.com/AhaLabs/soroban-astro-template",
+            "https://github.com/stellar/soroban-astro-template",
             &with_examples,
         )
         .unwrap();


### PR DESCRIPTION
### What

We're moving to use stellar/soroban-astro-template instead.

### Why

So everything is under SDF's org account.

### Known limitations

N/A
