### PR TITLE
fix(init): don't gitignore triple-dash

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/init.rs
+++ b/cmd/soroban-cli/src/commands/contract/init.rs
@@ -422,14 +422,14 @@ fn append_contents(from: &Path, to: &Path) -> Result<(), Error> {
 
 fn get_merged_file_delimiter(file_path: &Path) -> String {
     let comment = if file_path.to_string_lossy().contains("README.md") {
-        "[//]: # \"The following is the Frontend Template's README.md\"".to_string()
+        "---\n<!-- The following is the Frontend Template's README.md -->".to_string()
     } else if file_path.to_string_lossy().contains("gitignore") {
         "# The following is from the Frontend Template's .gitignore".to_string()
     } else {
         String::new()
     };
 
-    format!("\n\n---\n\n{comment}\n\n").to_string()
+    format!("\n\n{comment}\n\n").to_string()
 }
 
 #[cfg(test)]
@@ -691,13 +691,12 @@ mod tests {
         let readme_path = project_dir.join("README.md");
         let readme_str = read_to_string(readme_path).unwrap();
         assert!(readme_str.contains("Soroban Frontend in Astro"));
-        let expected = "[//]: # \"The following is the Frontend Template's README.md\"";
+        let expected = "The following is the Frontend Template's README.md";
         assert!(readme_str.contains(expected));
 
         let readme_path = project_dir.join("README.md");
         let readme_str = read_to_string(readme_path).unwrap();
-        let readme_frontend_merge_delimiter =
-            "[//]: # \"The following is the Frontend Template's README.md\"";
+        let readme_frontend_merge_delimiter = "The following is the Frontend Template's README.md";
         let count = readme_str.matches(readme_frontend_merge_delimiter).count();
         // making sure it is in there just once so that it isn't duplicated if `contract init` is run again
         assert!(count == 1);


### PR DESCRIPTION
The `---` is only for the `README.md` file, not `gitignore`.

I've also switched the "(ab)used link label (for use with reference
style links)"-style comment (`[//] #`) for an HTML comment (`<!-- ...
-->`). This means it will be rendered in the HTML, which might be
preferable, and is at a minimum benign. I hadn't been familiar with the
`[//]: #`-style comment until I saw it here (and searched to find a
description of it, along with the "(ab)use" line above, [here]), and I
don't think it's worth the potential confusion for users of `soroban
contract init`.

  [here]: https://stackoverflow.com/a/20885980/249801

