### PR TITLE
Removed extra output line in optimization

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/optimize.rs
+++ b/cmd/soroban-cli/src/commands/contract/optimize.rs
@@ -48,7 +48,6 @@ impl Cmd {
             wasm_out.set_extension("optimized.wasm");
             wasm_out
         });
-        println!("Writing to: {}...", wasm_out.to_string_lossy());
 
         let mut options = OptimizationOptions::new_optimize_for_size_aggressively();
         options.converge = true;


### PR DESCRIPTION
### What
Removed output line in optimization saying that a file will be written.

### Example
#### Before
```console
$ soroban contract optimize --wasm ./out/webauthn_factory.wasm
Reading: ./out/webauthn_factory.wasm (661 bytes)
Writing to: ./out/webauthn_factory.optimized.wasm...
Optimized: ./out/webauthn_factory.optimized.wasm (586 bytes)
```
#### After
```console
$ soroban contract optimize --wasm ./out/webauthn_factory.wasm
Reading: ./out/webauthn_factory.wasm (661 bytes)
Optimized: ./out/webauthn_factory.optimized.wasm (586 bytes)
```
### Why
It is immediately followed with an output line that the file has been written, and the duplicate lines is unnecessary noise in the output.