### PR TITLE
Output TransactionEnvelope instead of Transaction for --build-only

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -4,8 +4,7 @@ use soroban_env_host::{
         Asset, ContractDataDurability, ContractExecutable, ContractIdPreimage, CreateContractArgs,
         Error as XdrError, Hash, HostFunction, InvokeHostFunctionOp, LedgerKey::ContractData,
         LedgerKeyContractData, Limits, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
-        ScAddress, ScVal, SequenceNumber, Transaction, TransactionEnvelope, TransactionExt,
-        TransactionV1Envelope, Uint256, VecM, WriteXdr,
+        ScAddress, ScVal, SequenceNumber, Transaction, TransactionExt, Uint256, VecM, WriteXdr,
     },
     HostError,
 };
@@ -16,7 +15,7 @@ use crate::{
     commands::{
         config::{self, data},
         global, network,
-        txn_result::TxnResult,
+        txn_result::{TxnEnvelopeResult, TxnResult},
         NetworkRunnable,
     },
     rpc::{Client, Error as SorobanRpcError},
@@ -68,17 +67,10 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self) -> Result<(), Error> {
-        let res = self.run_against_rpc_server(None, None).await?;
+        let res = self.run_against_rpc_server(None, None).await?.to_envelope();
         match res {
-            TxnResult::Txn(tx) => println!(
-                "{}",
-                TransactionEnvelope::Tx(TransactionV1Envelope {
-                    tx,
-                    signatures: VecM::default()
-                })
-                .to_xdr_base64(Limits::none())?
-            ),
-            TxnResult::Res(contract) => {
+            TxnEnvelopeResult::TxnEnvelope(tx) => println!("{}", tx.to_xdr_base64(Limits::none())?),
+            TxnEnvelopeResult::Res(contract) => {
                 println!("{contract}");
             }
         }

--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -3,8 +3,9 @@ use soroban_env_host::{
     xdr::{
         Asset, ContractDataDurability, ContractExecutable, ContractIdPreimage, CreateContractArgs,
         Error as XdrError, Hash, HostFunction, InvokeHostFunctionOp, LedgerKey::ContractData,
-        LedgerKeyContractData, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
-        ScAddress, ScVal, SequenceNumber, Transaction, TransactionExt, Uint256, VecM,
+        LedgerKeyContractData, Limits, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
+        ScAddress, ScVal, SequenceNumber, Transaction, TransactionEnvelope, TransactionExt,
+        TransactionV1Envelope, Uint256, VecM, WriteXdr,
     },
     HostError,
 };
@@ -67,8 +68,20 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self) -> Result<(), Error> {
-        let res_str = self.run_against_rpc_server(None, None).await?;
-        println!("{res_str}");
+        let res = self.run_against_rpc_server(None, None).await?;
+        match res {
+            TxnResult::Txn(tx) => println!(
+                "{}",
+                TransactionEnvelope::Tx(TransactionV1Envelope {
+                    tx,
+                    signatures: VecM::default()
+                })
+                .to_xdr_base64(Limits::none())?
+            ),
+            TxnResult::Res(contract) => {
+                println!("{contract}");
+            }
+        }
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -9,7 +9,7 @@ use soroban_env_host::{
         AccountId, ContractExecutable, ContractIdPreimage, ContractIdPreimageFromAddress,
         CreateContractArgs, Error as XdrError, Hash, HostFunction, InvokeHostFunctionOp, Limits,
         Memo, MuxedAccount, Operation, OperationBody, Preconditions, PublicKey, ScAddress,
-        SequenceNumber, Transaction, TransactionEnvelope, TransactionExt, TransactionV1Envelope,
+        SequenceNumber, Transaction, TransactionExt,
         Uint256, VecM, WriteXdr,
     },
     HostError,
@@ -19,7 +19,7 @@ use crate::commands::{
     config::data,
     contract::{self, id::wasm::get_contract_id},
     global, network,
-    txn_result::TxnResult,
+    txn_result::{TxnEnvelopeResult, TxnResult},
     NetworkRunnable,
 };
 use crate::{
@@ -105,17 +105,10 @@ pub enum Error {
 
 impl Cmd {
     pub async fn run(&self) -> Result<(), Error> {
-        let res = self.run_against_rpc_server(None, None).await?;
+        let res = self.run_against_rpc_server(None, None).await?.to_envelope();
         match res {
-            TxnResult::Txn(tx) => println!(
-                "{}",
-                TransactionEnvelope::Tx(TransactionV1Envelope {
-                    tx,
-                    signatures: VecM::default()
-                })
-                .to_xdr_base64(Limits::none())?
-            ),
-            TxnResult::Res(contract) => {
+            TxnEnvelopeResult::TxnEnvelope(tx) => println!("{}", tx.to_xdr_base64(Limits::none())?),
+            TxnEnvelopeResult::Res(contract) => {
                 println!("{contract}");
             }
         }

--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -9,8 +9,7 @@ use soroban_env_host::{
         AccountId, ContractExecutable, ContractIdPreimage, ContractIdPreimageFromAddress,
         CreateContractArgs, Error as XdrError, Hash, HostFunction, InvokeHostFunctionOp, Limits,
         Memo, MuxedAccount, Operation, OperationBody, Preconditions, PublicKey, ScAddress,
-        SequenceNumber, Transaction, TransactionExt,
-        Uint256, VecM, WriteXdr,
+        SequenceNumber, Transaction, TransactionExt, Uint256, VecM, WriteXdr,
     },
     HostError,
 };

--- a/cmd/soroban-cli/src/commands/contract/extend.rs
+++ b/cmd/soroban-cli/src/commands/contract/extend.rs
@@ -5,7 +5,8 @@ use soroban_env_host::xdr::{
     Error as XdrError, ExtendFootprintTtlOp, ExtensionPoint, LedgerEntry, LedgerEntryChange,
     LedgerEntryData, LedgerFootprint, Limits, Memo, MuxedAccount, Operation, OperationBody,
     Preconditions, SequenceNumber, SorobanResources, SorobanTransactionData, Transaction,
-    TransactionExt, TransactionMeta, TransactionMetaV3, TtlEntry, Uint256, WriteXdr,
+    TransactionEnvelope, TransactionExt, TransactionMeta, TransactionMetaV3, TransactionV1Envelope,
+    TtlEntry, Uint256, VecM, WriteXdr,
 };
 
 use crate::{
@@ -91,7 +92,14 @@ impl Cmd {
     pub async fn run(&self) -> Result<(), Error> {
         let res = self.run_against_rpc_server(None, None).await?;
         match res {
-            TxnResult::Txn(tx) => println!("{}", tx.to_xdr_base64(Limits::none())?),
+            TxnResult::Txn(tx) => println!(
+                "{}",
+                TransactionEnvelope::Tx(TransactionV1Envelope {
+                    tx,
+                    signatures: VecM::default()
+                })
+                .to_xdr_base64(Limits::none())?
+            ),
             TxnResult::Res(ttl_ledger) => {
                 if self.ttl_ledger_only {
                     println!("{ttl_ledger}");

--- a/cmd/soroban-cli/src/commands/contract/extend.rs
+++ b/cmd/soroban-cli/src/commands/contract/extend.rs
@@ -4,8 +4,8 @@ use clap::{command, Parser};
 use soroban_env_host::xdr::{
     Error as XdrError, ExtendFootprintTtlOp, ExtensionPoint, LedgerEntry, LedgerEntryChange,
     LedgerEntryData, LedgerFootprint, Limits, Memo, MuxedAccount, Operation, OperationBody,
-    Preconditions, SequenceNumber, SorobanResources, SorobanTransactionData, Transaction, TransactionExt, TransactionMeta, TransactionMetaV3,
-    TtlEntry, Uint256, WriteXdr,
+    Preconditions, SequenceNumber, SorobanResources, SorobanTransactionData, Transaction,
+    TransactionExt, TransactionMeta, TransactionMetaV3, TtlEntry, Uint256, WriteXdr,
 };
 
 use crate::{

--- a/cmd/soroban-cli/src/commands/contract/install.rs
+++ b/cmd/soroban-cli/src/commands/contract/install.rs
@@ -6,8 +6,8 @@ use clap::{command, Parser};
 use soroban_env_host::xdr::{
     self, ContractCodeEntryExt, Error as XdrError, Hash, HostFunction, InvokeHostFunctionOp,
     LedgerEntryData, Limits, Memo, MuxedAccount, Operation, OperationBody, Preconditions, ReadXdr,
-    ScMetaEntry, ScMetaV0, SequenceNumber, Transaction, TransactionExt, TransactionResult,
-    TransactionResultResult, Uint256, VecM, WriteXdr,
+    ScMetaEntry, ScMetaV0, SequenceNumber, Transaction, TransactionEnvelope, TransactionExt,
+    TransactionResult, TransactionResultResult, TransactionV1Envelope, Uint256, VecM, WriteXdr,
 };
 
 use super::restore;
@@ -73,11 +73,17 @@ pub enum Error {
 
 impl Cmd {
     pub async fn run(&self) -> Result<(), Error> {
-        let res_str = match self.run_against_rpc_server(None, None).await? {
-            TxnResult::Txn(tx) => tx.to_xdr_base64(Limits::none())?,
-            TxnResult::Res(hash) => hex::encode(hash),
+        match self.run_against_rpc_server(None, None).await? {
+            TxnResult::Txn(tx) => println!(
+                "{}",
+                TransactionEnvelope::Tx(TransactionV1Envelope {
+                    tx,
+                    signatures: VecM::default()
+                })
+                .to_xdr_base64(Limits::none())?
+            ),
+            TxnResult::Res(hash) => println!("{}", hex::encode(hash)),
         };
-        println!("{res_str}");
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/contract/install.rs
+++ b/cmd/soroban-cli/src/commands/contract/install.rs
@@ -6,8 +6,8 @@ use clap::{command, Parser};
 use soroban_env_host::xdr::{
     self, ContractCodeEntryExt, Error as XdrError, Hash, HostFunction, InvokeHostFunctionOp,
     LedgerEntryData, Limits, Memo, MuxedAccount, Operation, OperationBody, Preconditions, ReadXdr,
-    ScMetaEntry, ScMetaV0, SequenceNumber, Transaction, TransactionExt,
-    TransactionResult, TransactionResultResult, Uint256, VecM, WriteXdr,
+    ScMetaEntry, ScMetaV0, SequenceNumber, Transaction, TransactionExt, TransactionResult,
+    TransactionResultResult, Uint256, VecM, WriteXdr,
 };
 
 use super::restore;

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -16,8 +16,7 @@ use soroban_env_host::{
         LedgerFootprint, Limits, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
         PublicKey, ScAddress, ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef, ScVal, ScVec,
         SequenceNumber, SorobanAuthorizationEntry, SorobanResources, String32, StringM,
-        Transaction, TransactionExt, Uint256, VecM,
-        WriteXdr,
+        Transaction, TransactionExt, Uint256, VecM, WriteXdr,
     },
     HostError,
 };

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -13,10 +13,11 @@ use heck::ToKebabCase;
 use soroban_env_host::{
     xdr::{
         self, Hash, HostFunction, InvokeContractArgs, InvokeHostFunctionOp, LedgerEntryData,
-        LedgerFootprint, Memo, MuxedAccount, Operation, OperationBody, Preconditions, PublicKey,
-        ScAddress, ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef, ScVal, ScVec, SequenceNumber,
-        SorobanAuthorizationEntry, SorobanResources, String32, StringM, Transaction,
-        TransactionExt, Uint256, VecM,
+        LedgerFootprint, Limits, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
+        PublicKey, ScAddress, ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef, ScVal, ScVec,
+        SequenceNumber, SorobanAuthorizationEntry, SorobanResources, String32, StringM,
+        Transaction, TransactionEnvelope, TransactionExt, TransactionV1Envelope, Uint256, VecM,
+        WriteXdr,
     },
     HostError,
 };
@@ -273,7 +274,19 @@ impl Cmd {
 
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         let res = self.invoke(global_args).await?;
-        println!("{res}");
+        match res {
+            TxnResult::Txn(tx) => println!(
+                "{}",
+                TransactionEnvelope::Tx(TransactionV1Envelope {
+                    tx,
+                    signatures: VecM::default()
+                })
+                .to_xdr_base64(Limits::none())?
+            ),
+            TxnResult::Res(contract) => {
+                println!("{contract}");
+            }
+        }
         Ok(())
     }
 

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -5,7 +5,8 @@ use soroban_env_host::xdr::{
     Error as XdrError, ExtensionPoint, LedgerEntry, LedgerEntryChange, LedgerEntryData,
     LedgerFootprint, Limits, Memo, MuxedAccount, Operation, OperationBody, OperationMeta,
     Preconditions, RestoreFootprintOp, SequenceNumber, SorobanResources, SorobanTransactionData,
-    Transaction, TransactionExt, TransactionMeta, TransactionMetaV3, TtlEntry, Uint256, WriteXdr,
+    Transaction, TransactionEnvelope, TransactionExt, TransactionMeta, TransactionMetaV3,
+    TransactionV1Envelope, TtlEntry, Uint256, VecM, WriteXdr,
 };
 use stellar_strkey::DecodeError;
 
@@ -96,8 +97,15 @@ impl Cmd {
     pub async fn run(&self) -> Result<(), Error> {
         let expiration_ledger_seq = match self.run_against_rpc_server(None, None).await? {
             TxnResult::Res(res) => res,
-            TxnResult::Txn(xdr) => {
-                println!("{}", xdr.to_xdr_base64(Limits::none())?);
+            TxnResult::Txn(tx) => {
+                println!(
+                    "{}",
+                    TransactionEnvelope::Tx(TransactionV1Envelope {
+                        tx,
+                        signatures: VecM::default()
+                    })
+                    .to_xdr_base64(Limits::none())?
+                );
                 return Ok(());
             }
         };

--- a/cmd/soroban-cli/src/commands/txn_result.rs
+++ b/cmd/soroban-cli/src/commands/txn_result.rs
@@ -1,6 +1,4 @@
-use std::fmt::{Display, Formatter};
-
-use soroban_env_host::xdr::{Limits, Transaction, WriteXdr};
+use soroban_env_host::xdr::Transaction;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TxnResult<R> {
@@ -13,23 +11,6 @@ impl<R> TxnResult<R> {
         match self {
             TxnResult::Res(res) => Some(res),
             TxnResult::Txn(_) => None,
-        }
-    }
-}
-
-impl<V> Display for TxnResult<V>
-where
-    V: Display,
-{
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TxnResult::Txn(tx) => write!(
-                f,
-                "{}",
-                tx.to_xdr_base64(Limits::none())
-                    .map_err(|_| std::fmt::Error)?
-            ),
-            TxnResult::Res(value) => write!(f, "{value}"),
         }
     }
 }

--- a/cmd/soroban-cli/src/commands/txn_result.rs
+++ b/cmd/soroban-cli/src/commands/txn_result.rs
@@ -1,4 +1,4 @@
-use soroban_env_host::xdr::Transaction;
+use soroban_env_host::xdr::{Transaction, TransactionEnvelope, TransactionV1Envelope, VecM};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TxnResult<R> {
@@ -13,4 +13,22 @@ impl<R> TxnResult<R> {
             TxnResult::Txn(_) => None,
         }
     }
+
+    pub fn to_envelope(self) -> TxnEnvelopeResult<R> {
+        match self {
+            TxnResult::Txn(tx) => {
+                TxnEnvelopeResult::TxnEnvelope(TransactionEnvelope::Tx(TransactionV1Envelope {
+                    tx,
+                    signatures: VecM::default(),
+                }))
+            }
+            TxnResult::Res(res) => TxnEnvelopeResult::Res(res),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TxnEnvelopeResult<R> {
+    TxnEnvelope(TransactionEnvelope),
+    Res(R),
 }


### PR DESCRIPTION
### What
Output TransactionEnvelope instead of Transaction for --build-only

### Why
Tools should always output, and accept as input, full envelopes because otherwise other tools that the inputs/outputs are used with won’t know what type of transaction we’ve given them.

It’s a bit confusing because tools always use the term ‘transaction’ to talk about what they accept as input, but in reality when tools like the Lab and others say they accept or build a transaction, they actually mean a transaction envelope.