### PR TITLE
Do not auto add test account to keys

### DIFF
--- a/cmd/soroban-cli/src/commands/keys/ls.rs
+++ b/cmd/soroban-cli/src/commands/keys/ls.rs
@@ -26,11 +26,7 @@ impl Cmd {
     }
 
     pub fn ls(&self) -> Result<Vec<String>, Error> {
-        let mut list = self.config_locator.list_identities()?;
-        let test = "test".to_string();
-        if !list.contains(&test) {
-            list.push(test);
-        }
+        let list = self.config_locator.list_identities()?;
         Ok(list)
     }
 


### PR DESCRIPTION
### What
Remove the automatically added test key from the keys list.

### Why
The test key doesn't actually exist. When using `ls` it says one exists, but when attemting to run any other keys subcommand it errors saying:

```
$ soroban keys address test
error: Failed to find config identity for test
```

The test account is created by the soroban-test framework when running the RPC tests. There's no need for it to show up in the list, as it doesn't exist normally.